### PR TITLE
Fix invalid XMLDOC reference in HexLabelNodeAdorner summary

### DIFF
--- a/src/Core/Echo.Core/Graphing/Serialization/Dot/HexLabelNodeAdorner.cs
+++ b/src/Core/Echo.Core/Graphing/Serialization/Dot/HexLabelNodeAdorner.cs
@@ -4,7 +4,7 @@ namespace Echo.Core.Graphing.Serialization.Dot
 {
     /// <summary>
     /// Represents a node adorner that adds a label to a node containing the hexadecimal representation of the
-    /// node's identifier.
+    /// <see cref="IIdentifiedNode.Id"/> property.
     /// </summary>
     public class HexLabelNodeAdorner : IDotNodeAdorner
     {

--- a/src/Core/Echo.Core/Graphing/Serialization/Dot/HexLabelNodeAdorner.cs
+++ b/src/Core/Echo.Core/Graphing/Serialization/Dot/HexLabelNodeAdorner.cs
@@ -4,7 +4,7 @@ namespace Echo.Core.Graphing.Serialization.Dot
 {
     /// <summary>
     /// Represents a node adorner that adds a label to a node containing the hexadecimal representation of the
-    /// <see cref="INode.Id"/> property. 
+    /// node's identifier.
     /// </summary>
     public class HexLabelNodeAdorner : IDotNodeAdorner
     {


### PR DESCRIPTION
After the `Id` property was removed from the `INode` interface, a little XMLDOC reference became invalid and gave compiler warnings.