### PR TITLE
Undocumented read/write static fields using ldfld/stfld

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
@@ -55,7 +55,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
             Instructions = instructions;
             Architecture = instructions.Architecture;
             
-            var valueFactory = new UnknownValueFactory(this);
+            UnknownValueFactory = new UnknownValueFactory(this);
             
             Is32Bit = is32Bit;
             Status = VirtualMachineStatus.Idle;
@@ -63,8 +63,8 @@ namespace Echo.Platforms.AsmResolver.Emulation
             Dispatcher = new DefaultCilDispatcher();
             CliMarshaller = new DefaultCliMarshaller(this);
             MemoryAllocator = new DefaultMemoryAllocator(module, is32Bit);
-            MethodInvoker = new ReturnUnknownMethodInvoker(valueFactory, CliMarshaller);
-            StaticFieldFactory = new StaticFieldFactory(valueFactory);
+            MethodInvoker = new ReturnUnknownMethodInvoker(UnknownValueFactory, CliMarshaller);
+            StaticFieldFactory = new StaticFieldFactory(UnknownValueFactory);
             
             _services[typeof(ICilRuntimeEnvironment)] = this;
         }
@@ -129,6 +129,13 @@ namespace Echo.Platforms.AsmResolver.Emulation
 
         /// <inheritdoc />
         public StaticFieldFactory StaticFieldFactory
+        {
+            get;
+            set;
+        }
+
+        /// <inheritdoc />
+        public IUnknownValueFactory UnknownValueFactory
         {
             get;
             set;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFld.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFld.cs
@@ -52,7 +52,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                 switch (objectValue)
                 {
                     case { IsKnown: false }:
-                        fieldValue = new UnknownValue();
+                        fieldValue = environment.UnknownValueFactory.CreateUnknown(field.Signature.FieldType);
                         break;
 
                     case OValue { IsZero: { Value: TrileanValue.True } }:

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFld.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFld.cs
@@ -32,21 +32,39 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
             var objectValue = (ICliValue) stack.Pop();
 
             IConcreteValue fieldValue;
-            switch (objectValue)
+            if (field.IsStatic)
             {
-                case { IsKnown: false }:
-                    fieldValue = new UnknownValue();
-                    break;
+                // Undocumented: The runtime does allow access of static fields through the ldfld opcode.
+                // In this case, the object instance that is pushed is ignored, allowing constructs like:
+                //
+                //    ldnull
+                //    ldfld <some_static_field>
+                //
+                // without the runtime throwing a NullReferenceException.
                 
-                case OValue { IsZero: { Value: TrileanValue.True } }:
-                    return new DispatchResult(new NullReferenceException());
+                var staticField = environment.StaticFieldFactory.Get(field);
+                fieldValue = environment.CliMarshaller.ToCliValue(staticField.Value, field.Signature.FieldType);
+            }
+            else
+            {
+                // Attempt to dereference the object instance.
                 
-                case OValue { ReferencedObject: HleObjectValue compoundObject }:
-                    fieldValue = compoundObject.GetFieldValue(field);
-                    break;
-                
-                default:
-                    return DispatchResult.InvalidProgram();
+                switch (objectValue)
+                {
+                    case { IsKnown: false }:
+                        fieldValue = new UnknownValue();
+                        break;
+
+                    case OValue { IsZero: { Value: TrileanValue.True } }:
+                        return new DispatchResult(new NullReferenceException());
+
+                    case OValue { ReferencedObject: IDotNetObjectValue compoundObject }:
+                        fieldValue = compoundObject.GetFieldValue(field);
+                        break;
+
+                    default:
+                        return DispatchResult.InvalidProgram();
+                }
             }
 
             stack.Push(environment.CliMarshaller.ToCliValue(fieldValue, field.Signature.FieldType));

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ICilRuntimeEnvironment.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ICilRuntimeEnvironment.cs
@@ -1,8 +1,6 @@
 using System;
 using AsmResolver.DotNet;
-using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
-using Echo.Concrete.Values.ReferenceType;
 using Echo.Core.Code;
 using Echo.Platforms.AsmResolver.Emulation.Invocation;
 using Echo.Platforms.AsmResolver.Emulation.Values;
@@ -70,6 +68,13 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             get;
         }
-        
+
+        /// <summary>
+        /// Gets the object responsible for constructing new unknown values.
+        /// </summary>
+        IUnknownValueFactory UnknownValueFactory
+        {
+            get;
+        }
     }
 }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdFldTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdFldTest.cs
@@ -101,21 +101,22 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             Assert.IsAssignableFrom<NullReferenceException>(result.Exception);
         }
 
-        private void VerifyUndocumentedLoadStatic(IConcreteValue instanceObject, IConcreteValue fieldValue, ICliValue expectedValue)
+        private void VerifyUndocumentedLoadStatic(
+            string fieldName, IConcreteValue instanceObject, IConcreteValue fieldValue, ICliValue expectedValue)
         {
             var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
             var stack = ExecutionContext.ProgramState.Stack;
 
             // Set initial field value.
             var simpleClassType = LookupTestType(typeof(SimpleClass));
-            var intField = simpleClassType.Fields.First(f => f.Name == nameof(SimpleClass.StaticIntField));
-            environment.StaticFieldFactory.Get(intField).Value = fieldValue;
+            var field = simpleClassType.Fields.First(f => f.Name == fieldName);
+            environment.StaticFieldFactory.Get(field).Value = fieldValue;
 
             // Push random object.
             stack.Push(instanceObject);
 
             // Test.
-            var result = Dispatcher.Execute(ExecutionContext, new CilInstruction(CilOpCodes.Ldfld, intField));
+            var result = Dispatcher.Execute(ExecutionContext, new CilInstruction(CilOpCodes.Ldfld, field));
             Assert.True(result.IsSuccess);
             Assert.Equal(expectedValue, stack.Top);
         }
@@ -124,17 +125,26 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
         public void UndocumentedReadStaticFromAnyObjectReferenceShouldNotThrow()
         {
             var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
-            VerifyUndocumentedLoadStatic(new OValue(
+            var instanceObject = new OValue(
                 environment.MemoryAllocator.GetStringValue("Hello, world"),
                 true,
-                environment.Is32Bit), new Integer32Value(0x12345678), new I4Value(0x12345678));
+                environment.Is32Bit);
+            
+            VerifyUndocumentedLoadStatic(nameof(SimpleClass.StaticIntField), instanceObject, 
+                new Integer32Value(0x12345678), 
+                new I4Value(0x12345678));
         }
 
         [Fact]
         public void UndocumentedReadStaticFromNullReferenceShouldNotThrow()
         {
             var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
-            VerifyUndocumentedLoadStatic(OValue.Null(environment.Is32Bit), new Integer32Value(0x12345678), new I4Value(0x12345678));
+            
+            VerifyUndocumentedLoadStatic(
+                nameof(SimpleClass.StaticIntField), 
+                OValue.Null(environment.Is32Bit),
+                new Integer32Value(0x12345678), 
+                new I4Value(0x12345678));
         }
     }
 }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdsFldTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdsFldTest.cs
@@ -36,7 +36,6 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
         [Fact]
         public void ReadStaticIntField()
         {
-            var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
             var fieldValue = new Integer32Value(0x12345678);
             Verify(nameof(SimpleClass.StaticIntField), fieldValue, new I4Value(fieldValue.I32));
         }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/StFldTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/StFldTest.cs
@@ -125,7 +125,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
         }
 
         [Fact]
-        public void UndocumentedReadStaticFromAnyObjectReferenceShouldNotThrow()
+        public void UndocumentedWriteStaticFromAnyObjectReferenceShouldNotThrow()
         {
             var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
             var instanceObject = new OValue(
@@ -139,7 +139,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
         }
 
         [Fact]
-        public void UndocumentedReadStaticFromNullReferenceShouldNotThrow()
+        public void UndocumentedWriteStaticFromNullReferenceShouldNotThrow()
         {
             var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
             VerifyUndocumentedWriteStatic(

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/StFldTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/StFldTest.cs
@@ -104,5 +104,48 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             Assert.False(result.IsSuccess);
             Assert.IsAssignableFrom<NullReferenceException>(result.Exception);
         }
+
+        private void VerifyUndocumentedWriteStatic(IConcreteValue instanceObject, ICliValue stackValue, IConcreteValue expectedValue)
+        {
+            var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
+            var stack = ExecutionContext.ProgramState.Stack;
+
+            // Set initial field value.
+            var simpleClassType = LookupTestType(typeof(SimpleClass));
+            var field = simpleClassType.Fields.First(f => f.Name == nameof(SimpleClass.StaticIntField));
+
+            // Push random object.
+            stack.Push(instanceObject);
+            stack.Push(stackValue);
+
+            // Test.
+            var result = Dispatcher.Execute(ExecutionContext, new CilInstruction(CilOpCodes.Stfld, field));
+            Assert.True(result.IsSuccess);
+            Assert.Equal(expectedValue, environment.StaticFieldFactory.Get(field).Value);
+        }
+
+        [Fact]
+        public void UndocumentedReadStaticFromAnyObjectReferenceShouldNotThrow()
+        {
+            var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
+            var instanceObject = new OValue(
+                environment.MemoryAllocator.GetStringValue("Hello, world"),
+                true,
+                environment.Is32Bit);
+            
+            VerifyUndocumentedWriteStatic(instanceObject, 
+                new I4Value(0x12345678), 
+                new Integer32Value(0x12345678));
+        }
+
+        [Fact]
+        public void UndocumentedReadStaticFromNullReferenceShouldNotThrow()
+        {
+            var environment = ExecutionContext.GetService<ICilRuntimeEnvironment>();
+            VerifyUndocumentedWriteStatic(
+                OValue.Null(environment.Is32Bit), 
+                new I4Value(0x12345678),
+                new Integer32Value(0x12345678));
+        }
     }
 }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Mock/MockCilRuntimeEnvironment.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Mock/MockCilRuntimeEnvironment.cs
@@ -11,8 +11,9 @@ namespace Echo.Platforms.AsmResolver.Tests.Mock
     {
         public MockCilRuntimeEnvironment()
         {
+            UnknownValueFactory = new UnknownValueFactory(this);
             CliMarshaller = new DefaultCliMarshaller(this);
-            StaticFieldFactory = new StaticFieldFactory(new UnknownValueFactory(this));
+            StaticFieldFactory = new StaticFieldFactory(UnknownValueFactory);
         }
 
         public IInstructionSetArchitecture<CilInstruction> Architecture
@@ -55,6 +56,12 @@ namespace Echo.Platforms.AsmResolver.Tests.Mock
         {
             get;
             set;
+        }
+
+        /// <inheritdoc />
+        public IUnknownValueFactory UnknownValueFactory
+        {
+            get;
         }
 
         IMethodInvoker ICilRuntimeEnvironment.MethodInvoker => MethodInvoker;


### PR DESCRIPTION
Changes:
- Lets `ldfld` and `stfld` read/write static fields.
- Adds `UnknownValueFactory` property to `ICilRuntimeEnvironment`.

Closes #80 