### PR TITLE
DefaultCliMarshaller dependency change to ValueFactory

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
@@ -56,7 +56,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
             Status = VirtualMachineStatus.Idle;
             CurrentState = new CilProgramState(ValueFactory);
             Dispatcher = new CilDispatcher();
-            CliMarshaller = new DefaultCliMarshaller(this);
+            CliMarshaller = new DefaultCliMarshaller(ValueFactory);
             MethodInvoker = new ReturnUnknownMethodInvoker(ValueFactory);
             StaticFieldFactory = new StaticFieldFactory(ValueFactory);
             _services[typeof(ICilRuntimeEnvironment)] = this;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Values/DefaultCliMarshaller.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Values/DefaultCliMarshaller.cs
@@ -17,22 +17,22 @@ namespace Echo.Platforms.AsmResolver.Emulation.Values
         /// <summary>
         /// Creates a new instance of the <see cref="DefaultCliMarshaller"/> class.
         /// </summary>
-        /// <param name="environment">The environment this marshaller is for.</param>
-        public DefaultCliMarshaller(ICilRuntimeEnvironment environment)
+        /// <param name="valueFactory">The factory responsible for constructing concrete values.</param>
+        public DefaultCliMarshaller(IValueFactory valueFactory)
         {
-            Environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            ValueFactory = valueFactory ?? throw new ArgumentNullException(nameof(valueFactory));
         }
         
         /// <summary>
-        /// Gets the environment that the marshaller converts values for.
+        /// Gets the factory responsible for constructing concrete values.
         /// </summary>
-        public ICilRuntimeEnvironment Environment
+        public IValueFactory ValueFactory
         {
             get;
         }
 
         /// <inheritdoc />
-        public bool Is32Bit => Environment.Is32Bit;
+        public bool Is32Bit => ValueFactory.Is32Bit;
 
         /// <inheritdoc />
         public ICliValue ToCliValue(IConcreteValue value, TypeSignature originalType)
@@ -182,7 +182,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Values
                 return ToCliValue(value, enumType.GetEnumUnderlyingType());
             
             if (value is LleStructValue lleObjectValue)
-                return new StructValue(Environment.ValueFactory, lleObjectValue.Type, lleObjectValue.Contents);
+                return new StructValue(ValueFactory, lleObjectValue.Type, lleObjectValue.Contents);
 
             throw new NotSupportedException($"Invalid or unsupported value {value}.");
         }
@@ -299,7 +299,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Values
                         return ToCtsValue(value, enumType.GetEnumUnderlyingType());
 
                     var structValue = (StructValue) value;
-                    return new LleStructValue(Environment.ValueFactory, structValue.Type, structValue.Contents);
+                    return new LleStructValue(ValueFactory, structValue.Type, structValue.Contents);
                 }
 
                 default:

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Mock/MockCilRuntimeEnvironment.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Mock/MockCilRuntimeEnvironment.cs
@@ -14,8 +14,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Mock
         {
             Is32Bit = is32Bit;
             Module = module ?? throw new ArgumentNullException(nameof(module));
-            CliMarshaller = new DefaultCliMarshaller(this);
             ValueFactory = new DefaultValueFactory(module, is32Bit);
+            CliMarshaller = new DefaultCliMarshaller(ValueFactory);
             StaticFieldFactory = new StaticFieldFactory(ValueFactory);
         }
 


### PR DESCRIPTION
Allows us to create and use new marshaller without the need of instantiating virtual machine  