### PR TITLE
Fix CallVirt emulation on method without overrides

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirt.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirt.cs
@@ -69,7 +69,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                 type = type.BaseType?.Resolve();
             }
 
-            return implementation;
+            return implementation ?? baseMethod;
         }
 
         private static MethodDefinition TryFindImplicitImplementationInType(TypeDefinition type, MethodDefinition baseMethod)


### PR DESCRIPTION
If callvirt is emulated and there are no overrides for the given method, Echo would previously return a `null` error implementation which causes a `MissingMethodException`. This PR aims to fix that by returning the base method if no implementations were found.

I am unsure what the behavior should be when the base method is abstract. With this change, it will return that abstract method instead of null.
