### PR TITLE
Implement ldnull handler

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Constants/Ldnull.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Constants/Ldnull.cs
@@ -5,13 +5,18 @@ using Echo.Platforms.AsmResolver.Emulation.Values.Cli;
 
 namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Constants
 {
+    /// <summary>
+    /// Provides a handler for instructions with the <see cref="CilOpCodes.Ldnull"/> operation code.
+    /// </summary>
     public class Ldnull : FallThroughOpCodeHandler
     {
+        /// <inheritdoc />
         public override IReadOnlyCollection<CilCode> SupportedOpCodes => new[]
         {
             CilCode.Ldnull,
         };
 
+        /// <inheritdoc />
         public override DispatchResult Execute(CilExecutionContext context, CilInstruction instruction)
         {
             var environment = context.GetService<ICilRuntimeEnvironment>();

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Constants/Ldnull.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Constants/Ldnull.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using AsmResolver.PE.DotNet.Cil;
+using Echo.Concrete.Emulation;
+using Echo.Platforms.AsmResolver.Emulation.Values.Cli;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Constants
+{
+    public class Ldnull : FallThroughOpCodeHandler
+    {
+        public override IReadOnlyCollection<CilCode> SupportedOpCodes => new[]
+        {
+            CilCode.Ldnull,
+        };
+
+        public override DispatchResult Execute(CilExecutionContext context, CilInstruction instruction)
+        {
+            var environment = context.GetService<ICilRuntimeEnvironment>();
+            context.ProgramState.Stack.Push(OValue.Null(environment.Is32Bit));
+            return base.Execute(context, instruction);
+        }
+    }
+}

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Constants/LdnullTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Constants/LdnullTest.cs
@@ -1,0 +1,23 @@
+using AsmResolver.PE.DotNet.Cil;
+using Echo.Platforms.AsmResolver.Emulation.Values.Cli;
+using Echo.Platforms.AsmResolver.Tests.Mock;
+using Xunit;
+
+namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Constants
+{
+    public class LdnullTest : DispatcherTestBase
+    {
+        public LdnullTest(MockModuleFixture moduleFixture)
+            : base(moduleFixture)
+        {
+        }
+
+        [Fact]
+        public void LdNull()
+        {
+            var result = Dispatcher.Execute(ExecutionContext, new CilInstruction(CilOpCodes.Ldnull));
+            Assert.True(result.IsSuccess);
+            Assert.Equal(OValue.Null(false), ExecutionContext.ProgramState.Stack.Top);
+        }
+    }
+}


### PR DESCRIPTION
The [Opcode support status issue](https://github.com/Washi1337/Echo/issues/27) incorrectly listed `ldnull` as being implemented. This PR implements a handler for that opcode.