### PR TITLE
CIL Exception Handler Emulator Support

### DIFF
--- a/src/Core/Echo/IndexableStack.cs
+++ b/src/Core/Echo/IndexableStack.cs
@@ -47,6 +47,11 @@ namespace Echo
         /// </summary>
         /// <param name="value"></param>
         public virtual void Push(T value) => _items.Add(value);
+        
+        /// <summary>
+        /// Removes all elements from the stack.
+        /// </summary>
+        public virtual void Clear() => _items.Clear();
 
         /// <inheritdoc />
         public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
@@ -339,11 +339,11 @@ namespace Echo.Platforms.AsmResolver.Emulation
             if (!result.IsSuccess)
             {
                 // TODO: unwind stack and move to appropriate exception handler if there is any.
-                var exceptionPointer = result.ExceptionPointer.AsSpan();
-                if (!exceptionPointer.IsFullyKnown)
-                    throw new NotImplementedException("Exception handling is not implemented yet (unknown exception type).");
-
-                var type = exceptionPointer.AsObjectHandle(this).GetObjectType(); 
+                var exceptionObject = result.ExceptionObject;
+                if (exceptionObject.IsNull)
+                    throw new CilEmulatorException("A null exception object was thrown.");
+                
+                var type = exceptionObject.GetObjectType();
                 throw new NotImplementedException($"Exception handling is not implemented yet. ({type})");
             }
         }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CliMarshaller.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CliMarshaller.cs
@@ -68,6 +68,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             switch (type.ElementType)
             {
+                case ElementType.Boolean:
                 case ElementType.U1:
                 case ElementType.U2:
                 case ElementType.U4:

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/CilDispatchResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/CilDispatchResult.cs
@@ -1,13 +1,13 @@
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures.Types;
-using Echo.Memory;
 
 namespace Echo.Platforms.AsmResolver.Emulation.Dispatch
 {
     /// <summary>
     /// Provides information about the result of an instruction dispatch.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay}")]
     public readonly struct CilDispatchResult
     {
         private CilDispatchResult(ObjectHandle exceptionObject)
@@ -28,6 +28,9 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch
         {
             get;
         }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal object DebuggerDisplay => IsSuccess ? "Success" : ExceptionObject;
 
         /// <summary>
         /// Creates a new dispatch result indicating the dispatch was successful.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/CilDispatchResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/CilDispatchResult.cs
@@ -10,22 +10,21 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch
     /// </summary>
     public readonly struct CilDispatchResult
     {
-        private CilDispatchResult(BitVector? exceptionPointer)
+        private CilDispatchResult(ObjectHandle exceptionObject)
         {
-            ExceptionPointer = exceptionPointer;
+            ExceptionObject = exceptionObject;
         }
         
         /// <summary>
         /// Gets a value indicating whether the dispatch and evaluation of the instruction was successful. 
         /// </summary>
-        [MemberNotNullWhen(false, nameof(ExceptionPointer))]
-        public bool IsSuccess => ExceptionPointer is null;
+        public bool IsSuccess => ExceptionObject.IsNull;
 
         /// <summary>
-        /// When <see cref="IsSuccess"/> is <c>false</c>, gets a vector that represents the pointer to the exception
+        /// When <see cref="IsSuccess"/> is <c>false</c>, gets the o that represents the pointer to the exception
         /// that was thrown during the evaluation of the instruction.
         /// </summary>
-        public BitVector? ExceptionPointer
+        public ObjectHandle ExceptionObject
         {
             get;
         }
@@ -38,8 +37,8 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch
         /// <summary>
         /// Creates a new dispatch result indicating the dispatch failed with an exception.
         /// </summary>
-        /// <param name="exceptionPointer">The pointer to the exception that was thrown.</param>
-        public static CilDispatchResult Exception(BitVector exceptionPointer) => new(exceptionPointer);
+        /// <param name="exceptionObject">The handle to the exception object that was thrown.</param>
+        public static CilDispatchResult Exception(ObjectHandle exceptionObject) => new(exceptionObject);
 
         /// <summary>
         /// Creates a new dispatch result indicating the dispatch failed with an exception.
@@ -48,9 +47,8 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch
         /// <param name="type">The type of exception to allocate.</param>
         public static CilDispatchResult Exception(CilVirtualMachine machine, ITypeDescriptor type)
         {
-            long exceptionPointer = machine.Heap.AllocateObject(type, true);
-            var pointerVector = machine.ValueFactory.RentNativeInteger(exceptionPointer);
-            return new CilDispatchResult(pointerVector);
+            var exceptionObject = machine.Heap.AllocateObject(type, true).AsObjectHandle(machine);
+            return new CilDispatchResult(exceptionObject);
         }
 
         /// <summary>

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/EndFilterHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/EndFilterHandler.cs
@@ -1,0 +1,39 @@
+using AsmResolver.PE.DotNet.Cil;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
+{
+    /// <summary>
+    /// Implements a CIL instruction handler for <c>endfilter</c> operations.
+    /// </summary>
+    [DispatcherTableEntry(CilCode.Endfilter)]
+    public class EndFilterHandler : ICilOpCodeHandler
+    {
+        /// <inheritdoc />
+        public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
+        {
+            var evalStack = context.CurrentFrame.EvaluationStack;
+            var ehStack = context.CurrentFrame.ExceptionHandlerStack;
+
+            var filterResult = evalStack.Pop().Contents;
+            try
+            {
+                var exception = ehStack.Peek().ExceptionObject;
+                
+                // Attempt to handle the filter.
+                var result = ehStack.EndFilter(!filterResult.AsSpan().IsZero.ToBoolean());
+                if (!result.IsSuccess)
+                    return CilDispatchResult.Exception(result.ExceptionObject);
+
+                // We passed the filter, jump to the actual handler with the exception on top of the stack.
+                context.CurrentFrame.ProgramCounter = result.NextOffset;
+                evalStack.Push(exception);
+                
+                return CilDispatchResult.Success();
+            }
+            finally
+            {
+                context.Machine.ValueFactory.BitVectorPool.Return(filterResult);
+            }
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/EndFinallyHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/EndFinallyHandler.cs
@@ -8,15 +8,19 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
     [DispatcherTableEntry(CilCode.Endfinally)]
     public class EndFinallyHandler : ICilOpCodeHandler
     {
-         /// <inheritdoc />
-         public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction) 
-         {
-             var result = context.CurrentFrame.ExceptionHandlerStack.EndFinally();
-             if (!result.IsSuccess)
-                 return CilDispatchResult.Exception(result.ExceptionObject);
+        /// <inheritdoc />
+        public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction) 
+        {
+            // Attempt to handle the finally clause.
+            context.CurrentFrame.EvaluationStack.Clear();
+            var result = context.CurrentFrame.ExceptionHandlerStack.EndFinally();
+            if (!result.IsSuccess)
+                return CilDispatchResult.Exception(result.ExceptionObject);
              
-             context.CurrentFrame.ProgramCounter = result.NextOffset;
-             return CilDispatchResult.Success();
-         }
+            // We exited the finally without exceptions, jump to the leaving offset.
+            context.CurrentFrame.ProgramCounter = result.NextOffset;
+
+            return CilDispatchResult.Success();
+        }
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/EndFinallyHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/EndFinallyHandler.cs
@@ -1,0 +1,22 @@
+using AsmResolver.PE.DotNet.Cil;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
+{
+    /// <summary>
+    /// Implements a CIL instruction handler for <c>endfinally</c> operations.
+    /// </summary>
+    [DispatcherTableEntry(CilCode.Endfinally)]
+    public class EndFinallyHandler : ICilOpCodeHandler
+    {
+         /// <inheritdoc />
+         public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction) 
+         {
+             var result = context.CurrentFrame.ExceptionHandlerStack.EndFinally();
+             if (!result.IsSuccess)
+                 return CilDispatchResult.Exception(result.ExceptionObject);
+             
+             context.CurrentFrame.ProgramCounter = result.NextOffset;
+             return CilDispatchResult.Success();
+         }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/LeaveHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/LeaveHandler.cs
@@ -1,0 +1,19 @@
+using AsmResolver.PE.DotNet.Cil;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
+{
+    /// <summary>
+    /// Implements a CIL instruction handler for <c>leave</c> operations.
+    /// </summary>
+    [DispatcherTableEntry(CilCode.Leave, CilCode.Leave_S)]
+    public class LeaveHandler : ICilOpCodeHandler
+    {
+        /// <inheritdoc />
+        public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
+        {
+            int targetOffset = ((ICilLabel) instruction.Operand!).Offset;
+            context.CurrentFrame.ProgramCounter = context.CurrentFrame.ExceptionHandlerStack.Leave(targetOffset);
+            return CilDispatchResult.Success();
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/LeaveHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/LeaveHandler.cs
@@ -12,7 +12,11 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
         public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
         {
             int targetOffset = ((ICilLabel) instruction.Operand!).Offset;
+            
+            // Leave the EH, and jump to the next offset.
+            context.CurrentFrame.EvaluationStack.Clear();
             context.CurrentFrame.ProgramCounter = context.CurrentFrame.ExceptionHandlerStack.Leave(targetOffset);
+
             return CilDispatchResult.Success();
         }
     }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/RethrowHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/RethrowHandler.cs
@@ -1,0 +1,19 @@
+using AsmResolver.PE.DotNet.Cil;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
+{
+    /// <summary>
+    /// Implements a CIL instruction handler for <c>rethrow</c> operations.
+    /// </summary>
+    [DispatcherTableEntry(CilCode.Rethrow)]
+    public class RethrowHandler : ICilOpCodeHandler
+    {
+        /// <inheritdoc />
+        public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
+        {
+            context.CurrentFrame.EvaluationStack.Clear();
+            var exceptionObject = context.CurrentFrame.ExceptionHandlerStack.Peek().ExceptionObject;
+            return CilDispatchResult.Exception(exceptionObject);
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/ThrowHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/ThrowHandler.cs
@@ -7,15 +7,16 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
     /// Implements a CIL instruction handler for <c>throw</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Throw)]
-    public class ThrowHandler : FallThroughOpCodeHandler
+    public class ThrowHandler : ICilOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
         {
             var stack = context.CurrentFrame.EvaluationStack;
             var pool = context.Machine.ValueFactory.BitVectorPool;
 
             var value = stack.Pop();
+            stack.Clear();
 
             try
             {
@@ -25,7 +26,11 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
                 if (value.Contents.AsSpan().IsZero)
                     return CilDispatchResult.NullReference(context);
 
-                return CilDispatchResult.Exception(value.Contents.AsObjectHandle(context.Machine));
+                var exceptionObject = value.Contents.AsObjectHandle(context.Machine);
+                
+                // TODO: set stack trace.
+                
+                return CilDispatchResult.Exception(exceptionObject);
             }
             finally
             {

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/ThrowHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Exceptions/ThrowHandler.cs
@@ -1,7 +1,7 @@
 using AsmResolver.PE.DotNet.Cil;
 using Echo.Platforms.AsmResolver.Emulation.Stack;
 
-namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Exceptions
 {
     /// <summary>
     /// Implements a CIL instruction handler for <c>throw</c> operations.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallHandlerBase.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallHandlerBase.cs
@@ -30,7 +30,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
 
                 // If that resulted in any error, throw it.
                 if (!devirtualization.IsSuccess)
-                    return CilDispatchResult.Exception(new BitVector(devirtualization.ExceptionPointer.Value));
+                    return CilDispatchResult.Exception(devirtualization.ExceptionObject);
 
                 // Invoke it otherwise.
                 var result = Invoke(context, devirtualization.ResultingMethod, arguments);
@@ -134,7 +134,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
 
                 case InvocationResultType.Exception:
                     // There was an exception during the invocation. Throw it.
-                    return CilDispatchResult.Exception(result.Value!);
+                    return CilDispatchResult.Exception(result.ExceptionObject);
 
                 case InvocationResultType.Inconclusive:
                     // Method invoker was not able to handle the method call.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirtHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirtHandler.cs
@@ -28,9 +28,11 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                     return MethodDevirtualizationResult.Unknown(); 
                 
                 case { IsZero.Value: TrileanValue.True }:
-                    return MethodDevirtualizationResult.Exception(context.Machine.Heap.AllocateObject(
-                        context.Machine.ValueFactory.NullReferenceExceptionType, 
-                        true));
+                    return MethodDevirtualizationResult.Exception(context.Machine
+                        .Heap.AllocateObject(
+                            context.Machine.ValueFactory.NullReferenceExceptionType,
+                            true)
+                        .AsObjectHandle(context.Machine));
                 
                 case var objectPointer:
                     var objectType = objectPointer.AsObjectHandle(context.Machine).GetObjectType();
@@ -38,9 +40,11 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
 
                     if (implementation is null)
                     {
-                        return MethodDevirtualizationResult.Exception(context.Machine.Heap.AllocateObject(
-                            context.Machine.ValueFactory.MissingMethodExceptionType,
-                            true));
+                        return MethodDevirtualizationResult.Exception(context.Machine
+                            .Heap.AllocateObject(
+                                context.Machine.ValueFactory.MissingMethodExceptionType,
+                                true)
+                            .AsObjectHandle(context.Machine));
                     }
                     
                     return MethodDevirtualizationResult.Success(implementation);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/MethodDevirtualizationResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/MethodDevirtualizationResult.cs
@@ -8,10 +8,10 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// </summary>
     public readonly struct MethodDevirtualizationResult 
     {
-        private MethodDevirtualizationResult(IMethodDescriptor? method, long? exception)
+        private MethodDevirtualizationResult(IMethodDescriptor? method, ObjectHandle exceptionObject)
         {
             ResultingMethod = method;
-            ExceptionPointer = exception;
+            ExceptionObject = exceptionObject;
         }
         
         /// <summary>
@@ -26,7 +26,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
         /// <summary>
         /// When unsuccessful, gets the exception thrown during the devirtualization process. 
         /// </summary>
-        public long? ExceptionPointer
+        public ObjectHandle ExceptionObject
         {
             get;
         }
@@ -35,30 +35,31 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
         /// Gets a value indicating whether the devirtualization process of the referenced method was successful.
         /// </summary>
         [MemberNotNullWhen(true, nameof(ResultingMethod))]
-        [MemberNotNullWhen(false, nameof(ExceptionPointer))]
         public bool IsSuccess => ResultingMethod is not null;
 
         /// <summary>
         /// Gets a value indicating whether the devirtualization process could not be completed due to an unknown
         /// object that was dereferenced.
         /// </summary>
-        public bool IsUnknown => !IsSuccess && ExceptionPointer is null;
+        public bool IsUnknown => !IsSuccess && ExceptionObject.IsNull;
 
         /// <summary>
         /// Creates a new successful method devirtualization result. 
         /// </summary>
         /// <param name="method">The resolved method.</param>
-        public static MethodDevirtualizationResult Success(IMethodDescriptor method) => new(method, null);
+        public static MethodDevirtualizationResult Success(IMethodDescriptor method) => new(method, default);
 
         /// <summary>
         /// Creates a new unsuccessful method devirtualization result.
         /// </summary>
-        /// <param name="exception">The exception that occurred during the method devirtualization.</param>
-        public static MethodDevirtualizationResult Exception(long exceptionPointer) => new(null, exceptionPointer);
+        /// <param name="exceptionObject">
+        /// The handle to the exception that occurred during the method devirtualization.
+        /// </param>
+        public static MethodDevirtualizationResult Exception(ObjectHandle exceptionObject) => new(null, exceptionObject);
 
         /// <summary>
         /// Creates a new unknown method devirtualization result.
         /// </summary>
-        public static MethodDevirtualizationResult Unknown() => new(null, null);
+        public static MethodDevirtualizationResult Unknown() => new(null, default);
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/MethodDevirtualizationResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/MethodDevirtualizationResult.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using AsmResolver.DotNet;
 
@@ -6,6 +7,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// <summary>
     /// Provides information about the result of a method devirtualization process.
     /// </summary>
+    [DebuggerDisplay("{Tag,nq}({DebuggerDisplay})")]
     public readonly struct MethodDevirtualizationResult 
     {
         private MethodDevirtualizationResult(IMethodDescriptor? method, ObjectHandle exceptionObject)
@@ -42,6 +44,12 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
         /// object that was dereferenced.
         /// </summary>
         public bool IsUnknown => !IsSuccess && ExceptionObject.IsNull;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal string Tag => IsUnknown ? "Unknown" : IsSuccess ? "Success" : "Exception";
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal object? DebuggerDisplay => IsSuccess ? ResultingMethod : ExceptionObject;
 
         /// <summary>
         /// Creates a new successful method devirtualization result. 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/ThrowHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/ThrowHandler.cs
@@ -25,7 +25,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                 if (value.Contents.AsSpan().IsZero)
                     return CilDispatchResult.NullReference(context);
 
-                return CilDispatchResult.Exception(value.Contents.Clone(pool));
+                return CilDispatchResult.Exception(value.Contents.AsObjectHandle(context.Machine));
             }
             finally
             {

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Variables/LdArgHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Variables/LdArgHandler.cs
@@ -29,7 +29,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Variables
             try
             {
                 // Marshal and push.
-                frame.ReadArgument(parameter.Index, result.AsSpan());
+                frame.ReadArgument(parameter.MethodSignatureIndex, result.AsSpan());
                 context.CurrentFrame.EvaluationStack.Push(result, parameterType);
             }
             finally

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Variables/StArgHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Variables/StArgHandler.cs
@@ -25,7 +25,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Variables
 
             // Pop top of stack into the parameter.
             var value = frame.EvaluationStack.Pop(parameterType);
-            frame.WriteArgument(parameter.Index, value.AsSpan());
+            frame.WriteArgument(parameter.MethodSignatureIndex, value.AsSpan());
             
             // Return rented bit vectors.
             factory.BitVectorPool.Return(value);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/EmptyUnknownResolver.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/EmptyUnknownResolver.cs
@@ -94,5 +94,14 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             return null;
         }
+
+        /// <inheritdoc />
+        public bool ResolveExceptionFilter(
+            CilExecutionContext context, 
+            CilInstruction instruction,
+            StackSlot conclusion)
+        {
+            return false;
+        }
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/EmulatedException.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/EmulatedException.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Echo.Platforms.AsmResolver.Emulation
+{
+    /// <summary>
+    /// Describes an exception that was thrown by emulated CIL code.
+    /// </summary>
+    public class EmulatedException : Exception
+    {
+        /// <summary>
+        /// Wraps the provided virtual exception object into an <see cref="EmulatedException"/> instance.
+        /// </summary>
+        /// <param name="exceptionObject">The handle to the virtual exception object.</param>
+        public EmulatedException(ObjectHandle exceptionObject)
+            : base($"An exception of type {exceptionObject.GetObjectType().FullName} was thrown by the emulated code.")
+        {
+            ExceptionObject = exceptionObject;
+        }
+
+        /// <summary>
+        /// Gets the handle to the virtual exception object that was thrown by the emulated CIL code.
+        /// </summary>
+        public ObjectHandle ExceptionObject
+        {
+            get;
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/IObjectMarshaller.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/IObjectMarshaller.cs
@@ -9,6 +9,14 @@ namespace Echo.Platforms.AsmResolver.Emulation
     public interface IObjectMarshaller
     {
         /// <summary>
+        /// Gets the machine the marshaller is targeting.
+        /// </summary>
+        CilVirtualMachine Machine
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Constructs a bit vector that represents the provided object.
         /// </summary>
         /// <param name="obj">The object.</param>

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/IUnknownResolver.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/IUnknownResolver.cs
@@ -88,5 +88,14 @@ namespace Echo.Platforms.AsmResolver.Emulation
         /// the method should be used.
         /// </returns>
         IMethodDescriptor? ResolveMethod(CilExecutionContext context, CilInstruction instruction, IList<BitVector> arguments);
+
+        /// <summary>
+        /// Resolves an unknown conclusion for an exception filter.
+        /// </summary>
+        /// <param name="context">The context in which the instruction is executed in.</param>
+        /// <param name="instruction">The instruction that is being executed.</param>
+        /// <param name="conclusion">The unknown conclusion value.</param>
+        /// <returns><c>true</c> if the exception should be handled, <c>false</c> otherwise.</returns>
+        bool ResolveExceptionFilter(CilExecutionContext context, CilInstruction instruction, StackSlot conclusion);
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/DefaultInvokers.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/DefaultInvokers.cs
@@ -33,6 +33,12 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
         public static ExternalMethodInvoker ReturnUnknownForExternal { get; } = new(ReturnUnknown, SignatureComparer.Default);
         
         /// <summary>
+        /// Gets the method invoker that steps over any method that does not have a CIL method body assigned by
+        /// returning an unknown result, and otherwise leaves the invocation result inconclusive.
+        /// </summary>
+        public static NativeMethodInvoker ReturnUnknownForNative { get; } = new(ReturnUnknown);
+        
+        /// <summary>
         /// Gets the method invoker that steps over any method by invoking it via System.Reflection. 
         /// </summary>
         public static ReflectionInvoker ReflectionInvoke => ReflectionInvoker.Instance;
@@ -43,6 +49,13 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
         /// </summary>
         /// <param name="baseInvoker">The invoker to use for producing a result when stepping over a method.</param>
         public static ExternalMethodInvoker HandleExternalWith(IMethodInvoker baseInvoker) => new(baseInvoker, SignatureComparer.Default);
+        
+        /// <summary>
+        /// Gets the method invoker that forwards any method that does not have a CIL method body assigned to the
+        /// provided method invoker, and otherwise leaves the invocation result inconclusive.
+        /// </summary>
+        /// <param name="baseInvoker">The invoker to use for producing a result when stepping over a method.</param>
+        public static NativeMethodInvoker HandleNativeWith(IMethodInvoker baseInvoker) => new(baseInvoker);
         
         /// <summary>
         /// Creates a new method shim invoker that multiplexes a set of methods to individual handlers.  

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/InvocationResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/InvocationResult.cs
@@ -8,10 +8,11 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
     /// </summary>
     public readonly struct InvocationResult
     {
-        private InvocationResult(InvocationResultType resultType, BitVector? value)
+        private InvocationResult(InvocationResultType resultType, BitVector? value, ObjectHandle exceptionObject)
         {
             ResultType = resultType;
             Value = value;
+            ExceptionObject = exceptionObject;
         }
 
         /// <summary>
@@ -33,10 +34,19 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
         public bool IsSuccess => ResultType is InvocationResultType.StepIn or InvocationResultType.StepOver;
 
         /// <summary>
-        /// When <see cref="IsSuccess"/> is <c>false</c>, contains the pointer to the exception that was thrown.
-        /// Otherwise, contains the value that the method returned (if available).
+        /// When <see cref="ResultType"/> is <see cref="InvocationResultType.StepOver"/>, gets the value that the
+        /// method returned (if available).
         /// </summary>
         public BitVector? Value
+        {
+            get;
+        }
+
+        /// <summary>
+        /// When <see cref="ResultType"/> is <see cref="InvocationResultType.Exception"/>, gets the handle to the
+        /// exception object that was thrown.
+        /// </summary>
+        public ObjectHandle ExceptionObject
         {
             get;
         }
@@ -44,12 +54,12 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
         /// <summary>
         /// Constructs a new inconclusive invocation result, where the invocation was not handled yet.
         /// </summary>
-        public static InvocationResult Inconclusive() => new(InvocationResultType.Inconclusive, null);
+        public static InvocationResult Inconclusive() => new(InvocationResultType.Inconclusive, null, default);
         
         /// <summary>
         /// Constructs a new inconclusive invocation result, where the invocation was handled as a step-in action.
         /// </summary>
-        public static InvocationResult StepIn() => new(InvocationResultType.StepIn, null);
+        public static InvocationResult StepIn() => new(InvocationResultType.StepIn, null, default);
         
         /// <summary>
         /// Constructs a new inconclusive invocation result, where the invocation was fully handled by the invoker and
@@ -58,15 +68,18 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
         /// <param name="value">
         /// The result that was produced by the method, or <c>null</c> if the method does not return a value.
         /// </param>
-        public static InvocationResult StepOver(BitVector? value) => new(InvocationResultType.StepOver, value);
+        public static InvocationResult StepOver(BitVector? value) => new(InvocationResultType.StepOver, value, default);
         
         /// <summary>
         /// Constructs a new failed invocation result with the provided pointer to an exception object describing the
         /// error that occurred.
         /// </summary>
-        /// <param name="value">The pointer to the exception object that was thrown.</param>
+        /// <param name="exceptionObject">The handle to the exception object that was thrown.</param>
         /// <returns>The result.</returns>
-        public static InvocationResult Exception(BitVector value) => new(InvocationResultType.Exception, value);
+        public static InvocationResult Exception(ObjectHandle exceptionObject) => new(
+            InvocationResultType.Exception,
+         null, 
+            exceptionObject);
     }
 
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/InvocationResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/InvocationResult.cs
@@ -1,4 +1,5 @@
 
+using System.Diagnostics;
 using Echo.Memory;
 
 namespace Echo.Platforms.AsmResolver.Emulation.Invocation
@@ -6,6 +7,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
     /// <summary>
     /// Describes the result of an invocation of an external method. 
     /// </summary>
+    [DebuggerDisplay("{Tag,nq}({DebuggerDisplay})")]
     public readonly struct InvocationResult
     {
         private InvocationResult(InvocationResultType resultType, BitVector? value, ObjectHandle exceptionObject)
@@ -50,6 +52,12 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
         {
             get;
         }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal string Tag => ResultType.ToString();
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal object? DebuggerDisplay => IsSuccess ? Value : ExceptionObject;
         
         /// <summary>
         /// Constructs a new inconclusive invocation result, where the invocation was not handled yet.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/NativeMethodInvoker.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/NativeMethodInvoker.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using AsmResolver.DotNet;
+using Echo.Memory;
+using Echo.Platforms.AsmResolver.Emulation.Dispatch;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Invocation
+{
+    /// <summary>
+    /// Implements a method invoker that steps over any method that does not have a CIL method body assigned.
+    /// </summary>
+    public class NativeMethodInvoker : IMethodInvoker
+    {
+        /// <summary>
+        /// Creates a new native method invoker.
+        /// </summary>
+        /// <param name="baseInvoker">The invoker that is used when invoking a non-CIL method.</param>
+        public NativeMethodInvoker(IMethodInvoker baseInvoker)
+        {
+            BaseInvoker = baseInvoker;
+        }
+        
+        /// <summary>
+        /// Gets the invoker that is used when invoking a non-CIL method.
+        /// </summary>
+        public IMethodInvoker BaseInvoker
+        {
+            get;
+        }
+        
+        /// <inheritdoc />
+        public InvocationResult Invoke(CilExecutionContext context, IMethodDescriptor method, IList<BitVector> arguments)
+        {
+            var definition = method.Resolve();
+            return definition?.CilMethodBody is null 
+                ? BaseInvoker.Invoke(context, method, arguments) 
+                : InvocationResult.Inconclusive();
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/ReflectionInvoker.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Invocation/ReflectionInvoker.cs
@@ -42,7 +42,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Invocation
             }
             catch (Exception ex)
             {
-                return InvocationResult.Exception(marshaller.ToBitVector(ex));
+                return InvocationResult.Exception(marshaller.ToObjectHandle(ex));
             }
         }
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectHandle.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectHandle.cs
@@ -39,6 +39,11 @@ namespace Echo.Platforms.AsmResolver.Emulation
         }
 
         /// <summary>
+        /// Gets a value indicating whether this handle represents the <c>null</c> reference.
+        /// </summary>
+        public bool IsNull => Address == 0;
+
+        /// <summary>
         /// Gets the address to the beginning of the object's data.
         /// </summary>
         public StructHandle Contents => new(Machine, Address + Machine.ValueFactory.ObjectHeaderSize);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectHandle.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectHandle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Memory;
 using AsmResolver.DotNet.Signatures.Types;
@@ -9,6 +10,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
     /// <summary>
     /// Represents an address to an object (including its object header) within a CIL virtual machine. 
     /// </summary>
+    [DebuggerDisplay("{Address} ({Tag})")]
     public readonly struct ObjectHandle : IEquatable<ObjectHandle>
     {
         /// <summary>
@@ -47,6 +49,25 @@ namespace Echo.Platforms.AsmResolver.Emulation
         /// Gets the address to the beginning of the object's data.
         /// </summary>
         public StructHandle Contents => new(Machine, Address + Machine.ValueFactory.ObjectHeaderSize);
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal string Tag
+        {
+            get
+            {
+                if (IsNull)
+                    return "null";
+
+                try
+                {
+                    return GetObjectType().FullName;
+                }
+                catch
+                {
+                    return "<invalid>";
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the object's type (or method table).
@@ -331,6 +352,6 @@ namespace Echo.Platforms.AsmResolver.Emulation
         }
 
         /// <inheritdoc />
-        public override string ToString() => Address.ToString(Machine.Is32Bit ? "X8" : "X16");
+        public override string ToString() => $"0x{Address.ToString(Machine.Is32Bit ? "X8" : "X16")}";
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshaller.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshaller.cs
@@ -21,9 +21,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
             Machine = machine;
         }
 
-        /// <summary>
-        /// Gets the machine the marshaller is targeting.
-        /// </summary>
+        /// <inheritdoc />
         public CilVirtualMachine Machine
         {
             get;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshallerExtensions.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshallerExtensions.cs
@@ -8,9 +8,15 @@ namespace Echo.Platforms.AsmResolver.Emulation
     /// </summary>
     public static class ObjectMarshallerExtensions
     {
-        public static ObjectHandle ToObjectHandle(this IObjectMarshaller self, object? value)
+        /// <summary>
+        /// Constructs an object handle that represents the provided object.
+        /// </summary>
+        /// <param name="self">The marshaller service.</param>
+        /// <param name="obj">The object.</param>
+        /// <returns>The bitvector containing the address to the object.</returns>
+        public static ObjectHandle ToObjectHandle(this IObjectMarshaller self, object? obj)
         {
-            return self.ToBitVector(value).AsObjectHandle(self.Machine);
+            return self.ToBitVector(obj).AsObjectHandle(self.Machine);
         }
         
         /// <summary>

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshallerExtensions.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshallerExtensions.cs
@@ -13,7 +13,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
         /// </summary>
         /// <param name="self">The marshaller service.</param>
         /// <param name="obj">The object.</param>
-        /// <returns>The bitvector containing the address to the object.</returns>
+        /// <returns>The handle containing the address to the marshalled object.</returns>
         public static ObjectHandle ToObjectHandle(this IObjectMarshaller self, object? obj)
         {
             return self.ToBitVector(obj).AsObjectHandle(self.Machine);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshallerExtensions.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectMarshallerExtensions.cs
@@ -8,6 +8,11 @@ namespace Echo.Platforms.AsmResolver.Emulation
     /// </summary>
     public static class ObjectMarshallerExtensions
     {
+        public static ObjectHandle ToObjectHandle(this IObjectMarshaller self, object? value)
+        {
+            return self.ToBitVector(value).AsObjectHandle(self.Machine);
+        }
+        
         /// <summary>
         /// Interprets the provided bit vector as an object of the provided type.
         /// </summary>

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallFrame.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallFrame.cs
@@ -167,6 +167,14 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         public IReadOnlyList<ExceptionHandlerFrame> ExceptionHandlers => _exceptionHandlers;
 
         /// <summary>
+        /// Gets the stack of currently active exception handler frames in the method.
+        /// </summary>
+        public ExceptionHandlerStack ExceptionHandlerStack
+        {
+            get;
+        } = new();
+
+        /// <summary>
         /// Gets the number of bytes (excluding the evaluation stack) the stack frame spans.
         /// </summary>
         public int Size => _localStorage.Count / 8;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallFrame.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallFrame.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
@@ -29,6 +30,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
 
         private readonly bool _initializeLocals;
         private readonly List<uint> _offsets = new();
+        private readonly List<ExceptionHandlerFrame> _exceptionHandlers = new();
         private BitVector _localStorage;
         private long _baseAddress;
 
@@ -52,9 +54,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             
             if (method.Signature is null)
                 throw new ArgumentException("Method does not have a valid signature.");
-            
-            uint pointerSize = factory.PointerSize;
-            
+
             var context = GenericContext.FromMethod(method);
             Method = method;
 
@@ -73,13 +73,13 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
 
                 foreach (var local in body.LocalVariables)
                     AllocateFrameField(local.VariableType);
-
+                
                 Body = body;
             }
 
             // Allocate return address.
             _offsets.Add(currentOffset);
-            currentOffset += pointerSize;
+            currentOffset += factory.PointerSize;
 
             // Allocate this parameter if required.
             if (method.Signature.HasThis)
@@ -90,7 +90,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
                 AllocateFrameField(parameterType);
 
             // Actually reserve space for the entire frame.
-            _localStorage = new BitVector((int) (currentOffset * pointerSize), false);
+            _localStorage = new BitVector((int) (currentOffset * factory.PointerSize), false);
             
             // Initialize locals to zero when method body says we should.
             if (_initializeLocals)
@@ -101,12 +101,14 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
                     .Write(new byte[localsSize]);
             }
 
+            InitializeExceptionHandlerFrames();
+            
             void AllocateFrameField(TypeSignature type)
             {
                 _offsets.Add(currentOffset);
                 var actualType = type.InstantiateGenericTypes(context);
                 currentOffset += factory.GetTypeValueMemoryLayout(actualType).Size;
-                currentOffset = currentOffset.Align(pointerSize);
+                currentOffset = currentOffset.Align(factory.PointerSize);
             }
         }
 
@@ -117,7 +119,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         {
             get;
         }
-        
+
         /// <summary>
         /// Gets the method which this frame was associated with.
         /// </summary>
@@ -150,7 +152,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             get;
             set;
         }
-        
+
         /// <summary>
         /// Gets a virtual evaluation stack associated stored the frame.
         /// </summary>
@@ -158,6 +160,11 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         {
             get;
         }
+
+        /// <summary>
+        /// Gets a collection of exception handler frames present in the method body.
+        /// </summary>
+        public IReadOnlyList<ExceptionHandlerFrame> ExceptionHandlers => _exceptionHandlers;
 
         /// <summary>
         /// Gets the number of bytes (excluding the evaluation stack) the stack frame spans.
@@ -211,7 +218,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         public long GetLocalAddress(int index) => index < LocalsCount
             ? _baseAddress + _offsets[index]
             : throw new ArgumentOutOfRangeException(nameof(index));
-        
+
         /// <summary>
         /// Reads the value of a local variable into a buffer. 
         /// </summary>
@@ -266,6 +273,25 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         public void Write(long address, ReadOnlySpan<byte> buffer)
         {
             _localStorage.AsSpan((int) (address - _baseAddress) * 8, buffer.Length).Write(buffer);
+        }
+
+        private void InitializeExceptionHandlerFrames()
+        {
+            if (Body is null)
+                return;
+
+            var merged = new Dictionary<AddressRange, ExceptionHandlerFrame>();
+            foreach (var range in Body.ExceptionHandlers.ToEchoRanges().OrderBy(x => x))
+            {
+                if (!merged.TryGetValue(range.ProtectedRange, out var frame))
+                {
+                    frame = new ExceptionHandlerFrame(range.ProtectedRange);
+                    merged.Add(range.ProtectedRange, frame);
+                    _exceptionHandlers.Add(frame);
+                }
+
+                frame.AddHandler((CilExceptionHandler) range.UserData);
+            }
         }
 
         /// <inheritdoc />

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/EvaluationStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/EvaluationStack.cs
@@ -19,6 +19,10 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             _factory = factory;
         }
 
+        /// <summary>
+        /// Puts the address of the provided object handle into a pointer-sized bit vector, and pushes it onto the stack.
+        /// </summary>
+        /// <param name="value">The handle to push.</param>
         public void Push(ObjectHandle value)
         {
             var vector = _factory.RentNativeInteger(value.Address);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/EvaluationStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/EvaluationStack.cs
@@ -19,6 +19,12 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             _factory = factory;
         }
 
+        public void Push(ObjectHandle value)
+        {
+            var vector = _factory.RentNativeInteger(value.Address);
+            Push(vector, _factory.ContextModule.CorLibTypeFactory.Object, true);
+        }
+        
         /// <summary>
         /// Marshals the provided bitvector into a stack slot, and pushes it onto the stack.
         /// </summary>
@@ -38,11 +44,8 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         /// <param name="value">The value to push.</param>
         /// <param name="originalType">The type of the value to push.</param>
         /// <returns>The stack slot that was created.</returns>
-        public void Push(BitVector value, TypeSignature originalType)
-        {
-            Push(value, originalType, false);
-        }
-        
+        public void Push(BitVector value, TypeSignature originalType) => Push(value, originalType, false);
+
         /// <summary>
         /// Marshals the provided bitvector into a stack slot, and pushes it onto the stack.
         /// </summary>
@@ -76,6 +79,15 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             _factory.BitVectorPool.Return(slot.Contents);
             
             return marshalled;
+        }
+
+        /// <inheritdoc />
+        public override void Clear()
+        {
+            for (int i = 0; i < Count; i++)
+                _factory.BitVectorPool.Return(this[i].Contents);
+
+            base.Clear();
         }
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerFrame.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerFrame.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AsmResolver.DotNet.Code.Cil;
+using Echo.Code;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Stack
+{
+    /// <summary>
+    /// Provides a mechanism for implementing exception handling for a single protected range within a single method body.
+    /// </summary>
+    public class ExceptionHandlerFrame
+    {
+        private readonly List<CilExceptionHandler> _handlers;
+        private int _currentHandlerIndex = -1;
+
+        /// <summary>
+        /// Creates a new exception handler frame.
+        /// </summary>
+        /// <param name="protectedRange">The IL offset range the exception handler is protecting.</param>
+        public ExceptionHandlerFrame(AddressRange protectedRange)
+        {
+            ProtectedRange = protectedRange;
+            _handlers = new List<CilExceptionHandler>();
+            Reset();
+        }
+        
+        /// <summary>
+        /// Gets the IL offset range the exception handler is protecting.
+        /// </summary>
+        public AddressRange ProtectedRange
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets a list of handlers that are associated to the protected range.
+        /// </summary>
+        public IReadOnlyList<CilExceptionHandler> Handlers => _handlers;
+
+        /// <summary>
+        /// Gets a value indicating whether the exception handler has a finalizer block.
+        /// </summary>
+        public bool HasFinalizer => Handlers.Any(x => x.HandlerType == CilExceptionHandlerType.Finally);
+        
+        /// <summary>
+        /// Gets the current active exception handler (if available).
+        /// </summary>
+        public CilExceptionHandler? CurrentHandler
+        {
+            get
+            {
+                if (_currentHandlerIndex < 0 || _currentHandlerIndex >= Handlers.Count)
+                    return null;
+                
+                return Handlers[_currentHandlerIndex];
+            }
+        }
+
+        /// <summary>
+        /// Gets the offset to jump to after a finalizer has exited (if available).
+        /// </summary>
+        public int? NextOffset
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the current exception object that was thrown within the protected range. 
+        /// </summary>
+        public ObjectHandle ExceptionObject
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the exception handler is currently handling the exception referenced
+        /// by <see cref="ExceptionObject"/>.
+        /// </summary>
+        public bool IsHandlingException
+        {
+            get;
+            private set;
+        }
+        
+        internal void AddHandler(CilExceptionHandler handler)
+        {
+            if (handler.TryStart?.Offset != ProtectedRange.Start || handler.TryEnd?.Offset != ProtectedRange.End)
+                throw new ArgumentException($"Exception handler does not protect the range {ProtectedRange}.");
+
+            _handlers.Add(handler);
+        }
+        
+        /// <summary>
+        /// Resets the exception handler to its initial state.
+        /// </summary>
+        public void Reset()
+        {
+            _currentHandlerIndex = -1;
+            NextOffset = null;
+            ExceptionObject = default;
+        }
+
+        /// <summary>
+        /// Registers the occurrence of an exception, and determines the next offset to jump to that will attempt
+        /// to handle the exception or finalize the code block.
+        /// </summary>
+        /// <param name="exceptionObject">The exception object.</param>
+        /// <returns></returns>
+        public int? RegisterException(ObjectHandle exceptionObject)
+        {
+            // If we are already handling an exception, and we are throwing a new exception, exception handling failed,
+            // and thus we must jump out.
+            if (IsHandlingException)
+            {
+                IsHandlingException = false;
+                return null;
+            }
+
+            // Only register the exception object if we don't have one already. We dot his because filter clauses can
+            // also throw exceptions, which are silently consumed by the runtime.
+            if (ExceptionObject.IsNull)
+                ExceptionObject = exceptionObject;
+            
+            return MoveToNextCompatibleHandler();
+        }
+
+        /// <summary>
+        /// Leaves either a protected range or an exception handler while marking the exception as handled successfully.
+        /// </summary>
+        /// <param name="leaveTargetOffset">The target offset to jump to.</param>
+        /// <returns>The offset to jump to.</returns>
+        public int Leave(int leaveTargetOffset)
+        {
+            // Save the target offset, such that any finalizer blocks can jump to it later.
+            NextOffset = leaveTargetOffset;
+
+            // Mark any exception as handled.  
+            ExceptionObject = default;
+            IsHandlingException = false;
+            
+            // TODO: support fault handlers.
+            return MoveToFinalizer() ?? leaveTargetOffset;
+        }
+
+        /// <summary>
+        /// Exits a finally block, and determines the next offset to jump to.
+        /// </summary>
+        /// <returns>The offset to jump to.</returns>
+        public int? EndFinally()
+        {
+            if (Handlers.All(x => x.HandlerType != CilExceptionHandlerType.Finally))
+                throw new CilEmulatorException("Operation requires an active finally exception handler.");
+            
+            return NextOffset;
+        }
+
+        /// <summary>
+        /// Exits a filter clause, and determines the next offset to jump to.
+        /// </summary>
+        /// <param name="result">
+        /// <c>true</c> if the exception should be handled by the current handler, <c>false</c> otherwise.
+        /// </param>
+        /// <returns>The offset to jump to.</returns>
+        public int? EndFilter(bool result)
+        {
+            if (CurrentHandler?.HandlerType != CilExceptionHandlerType.Filter)
+                throw new CilEmulatorException("Operation requires an active filter exception handler.");
+            
+            if (result)
+                return CurrentHandler.HandlerStart!.Offset;
+
+            return MoveToNextCompatibleHandler();
+        }
+
+        private int? MoveToNextCompatibleHandler()
+        {
+            _currentHandlerIndex++;
+
+            while (CurrentHandler is not null)
+            {
+                switch (CurrentHandler.HandlerType)
+                {
+                    case CilExceptionHandlerType.Exception:
+                        var supportedType = CurrentHandler.ExceptionType!.ToTypeSignature();
+                        var actualType = ExceptionObject.GetObjectType().ToTypeSignature();
+
+                        if (actualType.IsAssignableTo(supportedType))
+                        {
+                            IsHandlingException = true;
+                            return CurrentHandler.HandlerStart!.Offset;
+                        }
+
+                        break;
+                    
+                    case CilExceptionHandlerType.Filter:
+                        return CurrentHandler.FilterStart!.Offset;
+
+                    case CilExceptionHandlerType.Finally:
+                        return CurrentHandler.HandlerStart!.Offset;
+
+                    case CilExceptionHandlerType.Fault:
+                        // TODO: support fault handlers.
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+                
+                _currentHandlerIndex++;
+            }
+
+            return null;
+        }
+        
+        private int? MoveToFinalizer()
+        {
+            _currentHandlerIndex++;
+
+            while (CurrentHandler is not null)
+            {
+                if (CurrentHandler.HandlerType == CilExceptionHandlerType.Finally)
+                    return CurrentHandler.HandlerStart!.Offset;
+
+                _currentHandlerIndex++;
+            }
+
+            _currentHandlerIndex = -1;
+            return null;
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerFrame.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerFrame.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using AsmResolver.DotNet.Code.Cil;
 using Echo.Code;
@@ -9,6 +10,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
     /// <summary>
     /// Provides a mechanism for implementing exception handling for a single protected range within a single method body.
     /// </summary>
+    [DebuggerDisplay("Range = {ProtectedRange}, Handler Count = {Handlers.Count}, Next Offset = {NextOffset}")]
     public class ExceptionHandlerFrame
     {
         private readonly List<CilExceptionHandler> _handlers;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerResult.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics;
+
 namespace Echo.Platforms.AsmResolver.Emulation.Stack
 {
     /// <summary>
     /// Provides a discriminated union describing the result of an exception handler operation, containing either the
     /// next offset to jump to, or a handle to an unhandled exception object.
     /// </summary>
+    [DebuggerDisplay("{Tag,nq}({DebuggerDisplay})")]
     public readonly struct ExceptionHandlerResult
     {
         private ExceptionHandlerResult(int nextOffset, ObjectHandle exceptionObject)
@@ -32,6 +35,12 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         /// Gets a value indicating whether the handler operation was successful.
         /// </summary>
         public bool IsSuccess => ExceptionObject.IsNull;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal object Tag => IsSuccess ? "Success" : "Exception";
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        internal object DebuggerDisplay => IsSuccess ? NextOffset : ExceptionObject;
 
         /// <summary>
         /// Constructs a new successful exception handler result.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerResult.cs
@@ -1,0 +1,50 @@
+namespace Echo.Platforms.AsmResolver.Emulation.Stack
+{
+    /// <summary>
+    /// Provides a discriminated union describing the result of an exception handler operation, containing either the
+    /// next offset to jump to, or a handle to an unhandled exception object.
+    /// </summary>
+    public readonly struct ExceptionHandlerResult
+    {
+        private ExceptionHandlerResult(int nextOffset, ObjectHandle exceptionObject)
+        {
+            NextOffset = nextOffset;
+            ExceptionObject = exceptionObject;
+        }
+        
+        /// <summary>
+        /// When <see cref="IsSuccess"/> is <c>true</c>, contains the next IL offset to jump to within the current method. 
+        /// </summary>
+        public int NextOffset
+        {
+            get;
+        }
+
+        /// <summary>
+        /// When <see cref="IsSuccess"/> is <c>false</c>, contains the handle to the unhandled exception that was thrown.   
+        /// </summary>
+        public ObjectHandle ExceptionObject
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the handler operation was successful.
+        /// </summary>
+        public bool IsSuccess => ExceptionObject.IsNull;
+
+        /// <summary>
+        /// Constructs a new successful exception handler result.
+        /// </summary>
+        /// <param name="offset">The next IL offset to jump to.</param>
+        /// <returns>The result.</returns>
+        public static ExceptionHandlerResult Success(int offset) => new(offset, default);
+
+        /// <summary>
+        /// Constructs a new unsuccessful exception handler result.
+        /// </summary>
+        /// <param name="exceptionObject">The handle to the unhandled exception that was thrown.</param>
+        /// <returns>The result.</returns>
+        public static ExceptionHandlerResult Exception(ObjectHandle exceptionObject) => new(-1, exceptionObject);
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
@@ -45,20 +45,16 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             // Leaving an EH implies that we are leaving the EH safely without any unhandled exceptions.
             // We thus just need to find the next address to jump to.
             
-            while (Count > 0)
-            {
-                // Try let the current frame determine where to jump to.
-                var currentFrame = Peek();
-                int offset = currentFrame.Leave(targetOffset);
-                
-                // If the target offset falls within the current frame, we are jumping to one of our handlers.
-                if (currentFrame.ContainsOffset(offset))
-                    return offset;
+            // Try let the current frame determine where to jump to.
+            var currentFrame = Peek();
+            int offset = currentFrame.Leave(targetOffset);
+            
+            // If the target offset falls within the current frame, we are jumping to one of our handlers.
+            if (currentFrame.ContainsOffset(offset))
+                return offset;
 
-                // If the target offset falls outside the frame, we are actually leaving this frame.
-                Pop();
-            }
-
+            // If the target offset falls outside the frame, we are actually leaving this frame.
+            Pop();
             return targetOffset;
         }
 
@@ -103,7 +99,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             if (offset.HasValue)
             {
                 // We are safely leaving the frame.
-                return ExceptionHandlerResult.Success(Leave(offset.Value));
+                return ExceptionHandlerResult.Success(offset.Value);
             }
 
             // If the frame could not decide where to jump to, it means we left the protected region unexpectedly with

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
@@ -102,8 +102,8 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             int? offset = currentFrame.EndFinally();
             if (offset.HasValue)
             {
-                // We are safely leaving the frame.
-                return ExceptionHandlerResult.Success(offset.Value);
+                // We are leaving the frame.
+                return ExceptionHandlerResult.Success(Leave(offset.Value));
             }
 
             // If the frame could not decide where to jump to, it means we left the protected region unexpectedly with

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
@@ -47,13 +47,17 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
 
             while (Count > 0)
             {
-                // Try let the current frame determine where to jump to.
-                var currentFrame = Peek();
-                int offset = currentFrame.Leave(targetOffset);
+                // See if we are indeed leaving the current frame.
+                var currentFrame = Peek(); 
+                if (currentFrame.ContainsOffset(targetOffset))
+                    return targetOffset;
+                
+                // Let the frame determine where to jump to.
+                targetOffset = currentFrame.Leave(targetOffset);
 
-                // If the target offset falls within the current frame, we are jumping to one of our handlers.
-                if (currentFrame.ContainsOffset(offset))
-                    return offset;
+                // If the target offset still falls within the current frame, we are jumping to one of our handlers.
+                if (currentFrame.ContainsOffset(targetOffset))
+                    return targetOffset;
 
                 // If the target offset falls outside the frame, we are actually leaving this frame.
                 Pop();

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
@@ -44,17 +44,21 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         {
             // Leaving an EH implies that we are leaving the EH safely without any unhandled exceptions.
             // We thus just need to find the next address to jump to.
-            
-            // Try let the current frame determine where to jump to.
-            var currentFrame = Peek();
-            int offset = currentFrame.Leave(targetOffset);
-            
-            // If the target offset falls within the current frame, we are jumping to one of our handlers.
-            if (currentFrame.ContainsOffset(offset))
-                return offset;
 
-            // If the target offset falls outside the frame, we are actually leaving this frame.
-            Pop();
+            while (Count > 0)
+            {
+                // Try let the current frame determine where to jump to.
+                var currentFrame = Peek();
+                int offset = currentFrame.Leave(targetOffset);
+
+                // If the target offset falls within the current frame, we are jumping to one of our handlers.
+                if (currentFrame.ContainsOffset(offset))
+                    return offset;
+
+                // If the target offset falls outside the frame, we are actually leaving this frame.
+                Pop();
+            }
+
             return targetOffset;
         }
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/ExceptionHandlerStack.cs
@@ -1,0 +1,114 @@
+namespace Echo.Platforms.AsmResolver.Emulation.Stack
+{
+    /// <summary>
+    /// Implements the exception handling mechanism within a single managed method.
+    /// </summary>
+    public class ExceptionHandlerStack : IndexableStack<ExceptionHandlerFrame>
+    {
+        /// <summary>
+        /// Registers an exception, unwinds the exception handler stack and determines where to jump to within the
+        /// current method.
+        /// </summary>
+        /// <param name="exceptionObject">The handle to the exception that was thrown.</param>
+        /// <returns>
+        /// The offset to jump to next within the method, or the exception object if the exception was not handled
+        /// by the method.
+        /// </returns>
+        public ExceptionHandlerResult RegisterException(ObjectHandle exceptionObject)
+        {
+            // When an exception occurs, we need to find the handler that should be jumped to next. 
+            
+            while (Count > 0)
+            {
+                var currentFrame = Peek();
+
+                // Try let the current frame determine where to jump to.
+                int? offset = currentFrame.RegisterException(exceptionObject);
+                if (offset.HasValue)
+                    return ExceptionHandlerResult.Success(offset.Value);
+
+                // If the current frame could not handle the exception, see if we can find another frame that can.
+                Pop();
+            }
+
+            // No frame was able to handle the exception, report as unhandled.
+            return ExceptionHandlerResult.Exception(exceptionObject);
+        }
+        
+        /// <summary>
+        /// Safely leaves one or more exception handlers that are currently on the stack.
+        /// </summary>
+        /// <param name="targetOffset">The offset as indicated by the leave instruction.</param>
+        /// <returns>The offset to jump to next.</returns>
+        public int Leave(int targetOffset)
+        {
+            // Leaving an EH implies that we are leaving the EH safely without any unhandled exceptions.
+            // We thus just need to find the next address to jump to.
+            
+            while (Count > 0)
+            {
+                // Try let the current frame determine where to jump to.
+                var currentFrame = Peek();
+                int offset = currentFrame.Leave(targetOffset);
+                
+                // If the target offset falls within the current frame, we are jumping to one of our handlers.
+                if (currentFrame.ContainsOffset(offset))
+                    return offset;
+
+                // If the target offset falls outside the frame, we are actually leaving this frame.
+                Pop();
+            }
+
+            return targetOffset;
+        }
+
+        /// <summary>
+        /// Exits a filter clause with the provided result, and unwinds the exception handler stack if necessary.
+        /// </summary>
+        /// <param name="result">The result of the filter expression.</param>
+        /// <returns>
+        /// The offset to jump to next within the method, or the exception object if the exception was not handled
+        /// by the method.
+        /// </returns>
+        public ExceptionHandlerResult EndFilter(bool result)
+        {
+            // An endfilter only happens within the top-most frame when an exception occurred.
+            var currentFrame = Peek();
+            
+            // Try let the current frame determine where to jump to.
+            int? offset = currentFrame.EndFilter(result);
+            if (offset.HasValue)
+                return ExceptionHandlerResult.Success(offset.Value);
+            
+            // If the current frame could not handle the exception, bubble it up the stack.
+            return RegisterException(Pop().ExceptionObject);
+        }
+        
+        /// <summary>
+        /// Exits a finally clause, and unwinds the exception handler stack if necessary.
+        /// </summary>
+        /// <returns>
+        /// The offset to jump to next within the method, or the exception object if the exception was not handled
+        /// by the method.
+        /// </returns>
+        public ExceptionHandlerResult EndFinally()
+        {
+            // An endfinally occurs when we leave a handler either with or without an unhandled exception.
+            
+            // Endfinally always leaves the current EH frame.
+            var currentFrame = Pop();
+
+            // Let the current frame decide where to jump to next.  
+            int? offset = currentFrame.EndFinally();
+            if (offset.HasValue)
+            {
+                // We are safely leaving the frame.
+                return ExceptionHandlerResult.Success(Leave(offset.Value));
+            }
+
+            // If the frame could not decide where to jump to, it means we left the protected region unexpectedly with
+            // an exception. Bubble it up.
+            return RegisterException(currentFrame.ExceptionObject);
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ThrowUnknownResolver.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ThrowUnknownResolver.cs
@@ -93,5 +93,14 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             throw new CilEmulatorException($"Attempted to devirtualize method call {instruction} on an unknown object instance.");
         }
+
+        /// <inheritdoc />
+        public bool ResolveExceptionFilter(
+            CilExecutionContext context, 
+            CilInstruction instruction,
+            StackSlot conclusion)
+        {
+            throw new CilEmulatorException($"Attempted to execute {instruction} with an unknown resolution on the stack.");
+        }
     }
 }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/AddHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/AddHandlerTest.cs
@@ -45,7 +45,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arithmetic
             
             Assert.False(result.IsSuccess);
 
-            var type = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var type = result.ExceptionObject.GetObjectType();
             Assert.Equal(typeof(InvalidProgramException).FullName, type.FullName);
         }
     }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/DivHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/DivHandlerTest.cs
@@ -43,7 +43,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arithmetic
             
             Assert.False(result.IsSuccess);
 
-            var type = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var type = result.ExceptionObject.GetObjectType();
             Assert.Equal(typeof(InvalidProgramException).FullName, type.FullName);
         }
     }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/RemHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/RemHandlerTest.cs
@@ -51,7 +51,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arithmetic
             
             Assert.False(result.IsSuccess);
 
-            var type = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var type = result.ExceptionObject.GetObjectType();
             Assert.Equal(typeof(InvalidProgramException).FullName, type.FullName);
         }
     }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/SubHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arithmetic/SubHandlerTest.cs
@@ -45,7 +45,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arithmetic
             
             Assert.False(result.IsSuccess);
 
-            var type = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var type = result.ExceptionObject.GetObjectType();
             Assert.Equal(typeof(InvalidProgramException).FullName, type.FullName);
         }
     }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/LdElemHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/LdElemHandlerTest.cs
@@ -36,8 +36,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arrays
             
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Ldelem_I4));
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
 
         [Fact]
@@ -51,8 +51,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arrays
             
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Ldelem_I4));
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.IndexOutOfRangeException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.IndexOutOfRangeException", exceptionType.FullName);
         }
         
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/LdElemaHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/LdElemaHandlerTest.cs
@@ -39,8 +39,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arrays
                 Context.Machine.ContextModule.CorLibTypeFactory.Int32.Type));
             
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
         
         [Fact]
@@ -57,8 +57,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arrays
                 Context.Machine.ContextModule.CorLibTypeFactory.Int32.Type));
             
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.IndexOutOfRangeException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.IndexOutOfRangeException", exceptionType.FullName);
         }
         
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/LdNullHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/LdNullHandlerTest.cs
@@ -22,8 +22,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arrays
             
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Ldlen));
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
         
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/StElemHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Arrays/StElemHandlerTest.cs
@@ -26,8 +26,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Arrays
             
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Stelem_I4));
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.IndexOutOfRangeException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.IndexOutOfRangeException", exceptionType.FullName);
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CallVirtHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CallVirtHandlerTest.cs
@@ -83,8 +83,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Callvirt, baseMethod));
 
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer?.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CastHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CastHandlerTest.cs
@@ -67,7 +67,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             var result = Dispatcher.Dispatch(Context, new CilInstruction(code.ToOpCode(), targetType));
             
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var exceptionType = result.ExceptionObject.GetObjectType();
             Assert.Equal("System.InvalidCastException", exceptionType.FullName);
         }
 
@@ -107,7 +107,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             var result = Dispatcher.Dispatch(Context, new CilInstruction(code.ToOpCode(), targetType));
             
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var exceptionType = result.ExceptionObject.GetObjectType();
             Assert.Equal("System.InvalidCastException", exceptionType.FullName);
         }
 

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/ThrowHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/ThrowHandlerTest.cs
@@ -28,7 +28,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Throw));
             
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var exceptionType = result.ExceptionObject.GetObjectType();
             Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
 
@@ -50,7 +50,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Throw));
             
             Assert.False(result.IsSuccess);
-            var observedExceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
+            var observedExceptionType = result.ExceptionObject.GetObjectType();
             Assert.Equal(exceptionType, observedExceptionType, SignatureComparer.Default);
         }
     }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/CpBlkHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/CpBlkHandlerTest.cs
@@ -33,8 +33,8 @@ public class CpBlkHandlerTest : CilOpCodeHandlerTestBase
 
         // Verify
         Assert.False(result.IsSuccess);
-        var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-        Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+        var exceptionType = result.ExceptionObject.GetObjectType();
+        Assert.Equal("System.NullReferenceException", exceptionType.FullName);
     }
     
     [Fact]
@@ -56,8 +56,8 @@ public class CpBlkHandlerTest : CilOpCodeHandlerTestBase
 
         // Verify
         Assert.False(result.IsSuccess);
-        var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-        Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+        var exceptionType = result.ExceptionObject.GetObjectType();
+        Assert.Equal("System.NullReferenceException", exceptionType.FullName);
     }
     
     [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/InitBlkHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/InitBlkHandlerTest.cs
@@ -29,8 +29,8 @@ public class InitBlkHandlerTest : CilOpCodeHandlerTestBase
 
         // Verify
         Assert.False(result.IsSuccess);
-        var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-        Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+        var exceptionType = result.ExceptionObject.GetObjectType();
+        Assert.Equal("System.NullReferenceException", exceptionType.FullName);
     }
 
     [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/InitObjHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/InitObjHandlerTest.cs
@@ -30,8 +30,8 @@ public class InitObjHandlerTest : CilOpCodeHandlerTestBase
 
         // Verify
         Assert.False(result.IsSuccess);
-        var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-        Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+        var exceptionType = result.ExceptionObject.GetObjectType();
+        Assert.Equal("System.NullReferenceException", exceptionType.FullName);
     }
 
     [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/LdIndHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/LdIndHandlerTest.cs
@@ -23,8 +23,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Pointers
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Ldind_I4));
 
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/StIndHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Pointers/StIndHandlerTest.cs
@@ -24,8 +24,8 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Pointers
             var result = Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Stind_I4));
 
             Assert.False(result.IsSuccess);
-            var exceptionType = result.ExceptionPointer!.AsObjectHandle(Context.Machine).GetObjectType();
-            Assert.Equal("System.NullReferenceException", exceptionType?.FullName);
+            var exceptionType = result.ExceptionObject.GetObjectType();
+            Assert.Equal("System.NullReferenceException", exceptionType.FullName);
         }
 
         [Theory]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerFrameTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerFrameTest.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using AsmResolver.DotNet.Code.Cil;
+using Echo.Platforms.AsmResolver.Emulation;
+using Echo.Platforms.AsmResolver.Emulation.Stack;
+using Echo.Platforms.AsmResolver.Tests.Mock;
+using Mocks;
+using Xunit;
+
+namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
+{
+    public class ExceptionHandlerFrameTest : IClassFixture<MockModuleFixture>
+    {
+        private readonly MockModuleFixture _fixture;
+        private readonly CilVirtualMachine _vm;
+
+        public ExceptionHandlerFrameTest(MockModuleFixture fixture)
+        {
+            _fixture = fixture;
+            _vm = new CilVirtualMachine(_fixture.MockModule, false);
+        }
+
+        private CallFrame GetMockFrame(string methodName)
+        {
+            return _vm.CallStack.Push(_fixture.GetTestMethod(methodName));
+        }
+
+        [Fact]
+        public void LeaveShouldJumpToOffsetIfNoFinalizerPresent()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatch)).ExceptionHandlers.First(x => !x.HasFinalizer);
+
+            int? offset = frame.Leave(1337);
+            Assert.Equal(1337, offset);
+        }
+
+        [Fact]
+        public void LeaveShouldJumpToFinalizerIfPresent()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryFinally)).ExceptionHandlers.First(x => x.HasFinalizer);
+
+            int? offset = frame.Leave(1337);
+            Assert.Equal(
+                frame.Handlers.First(x => x.HandlerType == CilExceptionHandlerType.Finally).HandlerStart!.Offset,
+                offset);
+            Assert.Equal(1337, frame.NextOffset);
+        }
+
+        [Fact]
+        public void EndFinallyShouldJumpToLeaveOffsetIfPresent()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryFinally)).ExceptionHandlers.First(x => x.HasFinalizer);
+            frame.Leave(1337);
+            Assert.Equal(1337, frame.EndFinally());
+        }
+
+        [Fact]
+        public void EndFinallyShouldReturnNullIfNoLeave()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryFinally)).ExceptionHandlers.First(x => x.HasFinalizer);
+            Assert.False(frame.EndFinally().HasValue);
+        }
+
+        [Theory]
+        [InlineData(typeof(IOException), 0)]
+        [InlineData(typeof(WebException), 1)]
+        [InlineData(typeof(ArgumentException), null)]
+        public void RegisterExceptionShouldJumpToFirstCompatibleException(Type exceptionType, int? expectedIndex)
+        {
+            var exception = _vm.ObjectMarshaller.ToObjectHandle(Activator.CreateInstance(exceptionType));
+            var frame = GetMockFrame(nameof(TestClass.TryCatchCatch)).ExceptionHandlers[0];
+            
+            Assert.Equal(new[]
+            {
+                "System.IO.IOException",
+                "System.Net.WebException"
+            }, frame.Handlers.Select(x=>x.ExceptionType!.FullName));
+
+            int? offset = frame.RegisterException(exception);
+            if (expectedIndex.HasValue)
+                Assert.Same(frame.CurrentHandler, frame.Handlers[expectedIndex.Value]);
+            else
+                Assert.False(offset.HasValue);
+        }
+
+        [Fact]
+        public void RegisterExceptionInCatchClauseShouldReturnNull()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchSpecificAndGeneral)).ExceptionHandlers[0];
+            
+            Assert.Equal(new[]
+            {
+                "System.IO.EndOfStreamException",
+                "System.IO.IOException"
+            }, frame.Handlers.Select(x=>x.ExceptionType!.FullName));
+
+            Assert.True(frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new EndOfStreamException())).HasValue);
+            Assert.False(frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new IOException())).HasValue);
+        }
+
+        [Fact]
+        public void EndFilterTrueShouldJumpToHandler()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchFilters)).ExceptionHandlers[0];
+            frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new IOException()));
+            
+            int? offset = frame.EndFilter(true);
+            Assert.Equal(
+                frame.Handlers.First(x=>x.HandlerType == CilExceptionHandlerType.Filter).HandlerStart!.Offset,
+                offset);
+        }
+
+        [Fact]
+        public void EndFilterFalseShouldJumpToNextCompatibleHandler()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchFilters)).ExceptionHandlers[0];
+            frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new IOException()));
+            
+            int? offset = frame.EndFilter(false);
+            Assert.Equal(
+                frame.Handlers
+                    .Where(x => x.HandlerType == CilExceptionHandlerType.Filter)
+                    .ElementAt(1).FilterStart!.Offset,
+                offset);
+        }
+
+        [Fact]
+        public void RegisterExceptionDuringFilteringShouldMoveToNextHandler()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchFilters)).ExceptionHandlers[0];
+            
+            Assert.True(frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new IOException())).HasValue);
+            int? offset = frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new NullReferenceException()));
+            Assert.Equal(
+                frame.Handlers
+                    .Where(x => x.HandlerType == CilExceptionHandlerType.Filter)
+                    .ElementAt(1).FilterStart!.Offset,
+                offset);
+        }
+
+        [Fact]
+        public void RegisterExceptionDuringFilteringShouldReturnNullIfNoMoreCompatibleHandlers()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchFilters)).ExceptionHandlers[0];
+            
+            Assert.True(frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new IOException())).HasValue);
+            Assert.True(frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new NullReferenceException())).HasValue);
+            int? offset = frame.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new NullReferenceException()));
+            Assert.False(offset.HasValue);
+        }
+    }
+}

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
@@ -173,7 +173,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
 
             if (@throw)
             {
-                var result = frame.ExceptionHandlerStack.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new Exception()));
+                var result = frame.ExceptionHandlerStack.RegisterException(GetMockException<Exception>());
                 Assert.Equal(innerHandlerStart.Offset, result.NextOffset);
             }
             
@@ -265,7 +265,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
             
             if (@throw)
             {
-                result = frame.ExceptionHandlerStack.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new Exception()));
+                result = frame.ExceptionHandlerStack.RegisterException(GetMockException<Exception>());
                 Assert.Equal(handler1Start.Offset, result.NextOffset);
             }
             
@@ -440,7 +440,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
             frame.ExceptionHandlerStack.Push(frame.ExceptionHandlers[0]); // outer try-finally
             frame.ExceptionHandlerStack.Push(frame.ExceptionHandlers[1]); // try-catch
 
-            var result = frame.ExceptionHandlerStack.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new Exception()));
+            var result = frame.ExceptionHandlerStack.RegisterException(GetMockException<Exception>());
             Assert.Equal(innerHandlerStart.Offset, result.NextOffset);
             
             frame.ExceptionHandlerStack.Push(frame.ExceptionHandlers[2]); // inner try-finally

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
@@ -1,11 +1,18 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Echo.Platforms.AsmResolver.Emulation;
 using Echo.Platforms.AsmResolver.Emulation.Stack;
 using Echo.Platforms.AsmResolver.Tests.Mock;
 using Mocks;
 using Xunit;
+using static AsmResolver.PE.DotNet.Cil.CilOpCodes;
 
 namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
 {
@@ -90,6 +97,96 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
             var result = stack.RegisterException(GetMockException<ArgumentException>());
             Assert.True(result.IsSuccess);
             Assert.Equal(frame.ExceptionHandlers[0].Handlers[0].HandlerStart!.Offset, result.NextOffset);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void LeaveMultipleHandlers(bool @throw)
+        {
+            var factory = _fixture.MockModule.CorLibTypeFactory;
+            var method = new MethodDefinition("dummy", MethodAttributes.Static,
+                MethodSignature.CreateStatic(factory.Void));
+
+            var tryStart = new CilInstructionLabel();
+            var handler1Start = new CilInstructionLabel();
+            var handler2Start = new CilInstructionLabel();
+            var handler2End = new CilInstructionLabel();
+
+            method.CilMethodBody = new CilMethodBody(method)
+            {
+                Instructions =
+                {
+                    Nop,
+                    
+                    // try {
+                    Ldc_I4_1,
+                    Stloc_0,
+                    {Leave, handler2End},
+                    
+                    // } catch {
+                    Pop,
+                    Ldc_I4_2,
+                    Stloc_0,
+                    {Leave, handler2End},
+                    
+                    // } finally {
+                    Ldloc_0,
+                    {Ldc_I4, 100},
+                    Add,
+                    Stloc_0,
+                    Endfinally,
+                    // }
+                    
+                    Ldloc_0,
+                    Ret
+                },
+                ExceptionHandlers =
+                {
+                    new CilExceptionHandler
+                    {
+                        HandlerType = CilExceptionHandlerType.Exception,
+                        ExceptionType = factory.Object.Type,
+                        TryStart = tryStart,
+                        TryEnd = handler1Start,
+                        HandlerStart = handler1Start,
+                        HandlerEnd = handler2Start,
+                    },
+                    new CilExceptionHandler
+                    {
+                        HandlerType = CilExceptionHandlerType.Finally,
+                        ExceptionType = factory.Object.Type,
+                        TryStart = tryStart,
+                        TryEnd = handler2Start,
+                        HandlerStart = handler2Start,
+                        HandlerEnd = handler2End,
+                    }
+                }
+            };
+            
+            method.CilMethodBody.Instructions.CalculateOffsets();
+            tryStart.Instruction = method.CilMethodBody.Instructions[1];
+            handler1Start.Instruction = method.CilMethodBody.Instructions[4];
+            handler2Start.Instruction = method.CilMethodBody.Instructions[8];
+            handler2End.Instruction = method.CilMethodBody.Instructions[13];
+
+            var frame = new CallFrame(method, _vm.ValueFactory);
+            frame.ExceptionHandlerStack.Push(frame.ExceptionHandlers[0]);
+            frame.ExceptionHandlerStack.Push(frame.ExceptionHandlers[1]);
+
+            ExceptionHandlerResult result;
+            
+            if (@throw)
+            {
+                result = frame.ExceptionHandlerStack.RegisterException(_vm.ObjectMarshaller.ToObjectHandle(new Exception()));
+                Assert.Equal(handler1Start.Offset, result.NextOffset);
+            }
+            
+            int offset = frame.ExceptionHandlerStack.Leave(handler2End.Offset);
+            Assert.Equal(handler2Start.Offset, offset);
+        
+            result = frame.ExceptionHandlerStack.EndFinally();
+            Assert.Equal(handler2End.Offset, result.NextOffset);
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Net;
+using Echo.Platforms.AsmResolver.Emulation;
+using Echo.Platforms.AsmResolver.Emulation.Stack;
+using Echo.Platforms.AsmResolver.Tests.Mock;
+using Mocks;
+using Xunit;
+
+namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
+{
+    public class ExceptionHandlerStackTest : IClassFixture<MockModuleFixture>
+    {
+        private readonly MockModuleFixture _fixture;
+        private readonly CilVirtualMachine _vm;
+
+        public ExceptionHandlerStackTest(MockModuleFixture fixture)
+        {
+            _fixture = fixture;
+            _vm = new CilVirtualMachine(_fixture.MockModule, false);
+        }
+
+        private CallFrame GetMockFrame(string methodName)
+        {
+            return _vm.CallStack.Push(_fixture.GetTestMethod(methodName));
+        }
+
+        private ObjectHandle GetMockException(Type type)
+        {
+            return _vm.ObjectMarshaller.ToObjectHandle(Activator.CreateInstance(type));
+        }
+        
+        private ObjectHandle GetMockException<T>()
+        {
+            return _vm.ObjectMarshaller.ToObjectHandle(Activator.CreateInstance<T>());
+        }
+
+        [Fact]
+        public void ThrowUnhandledExceptionShouldJumpToFinalizer()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryFinally));
+            
+            var stack = frame.ExceptionHandlerStack;          
+            stack.Push(frame.ExceptionHandlers[0]); // try-finally
+            
+            var result = stack.RegisterException(GetMockException<Exception>());
+            Assert.True(result.IsSuccess);
+            Assert.Equal(frame.ExceptionHandlers[0].Handlers[0].HandlerStart!.Offset, result.NextOffset);
+        }
+
+        [Fact]
+        public void ThrowHandledExceptionShouldJumpToHandler()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchFinally));
+            
+            var stack = frame.ExceptionHandlerStack;          
+            stack.Push(frame.ExceptionHandlers[0]); // try-finally
+            stack.Push(frame.ExceptionHandlers[1]); // try-catch
+            
+            var result = stack.RegisterException(GetMockException<Exception>());
+            Assert.True(result.IsSuccess);
+            Assert.Equal(frame.ExceptionHandlers[1].Handlers[0].HandlerStart!.Offset, result.NextOffset);
+        }
+
+        [Theory]
+        [InlineData(typeof(IOException), 0)]
+        [InlineData(typeof(WebException), 1)]
+        public void ThrowSpecificHandledExceptionShouldJumpToHandler(Type exceptionType, int expectedHandlerIndex)
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchCatchFinally));
+            
+            var stack = frame.ExceptionHandlerStack;          
+            stack.Push(frame.ExceptionHandlers[0]); // try-finally
+            stack.Push(frame.ExceptionHandlers[1]); // try-catch
+            
+            var result = stack.RegisterException(GetMockException(exceptionType));
+            Assert.True(result.IsSuccess);
+            Assert.Equal(frame.ExceptionHandlers[1].Handlers[expectedHandlerIndex].HandlerStart!.Offset, result.NextOffset);
+        }
+
+        [Fact]
+        public void ThrowSpecificUnhandledExceptionShouldJumpToFinalizer()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryCatchCatchFinally));
+            
+            var stack = frame.ExceptionHandlerStack;          
+            stack.Push(frame.ExceptionHandlers[0]); // try-finally
+            stack.Push(frame.ExceptionHandlers[1]); // try-catch
+            
+            var result = stack.RegisterException(GetMockException<ArgumentException>());
+            Assert.True(result.IsSuccess);
+            Assert.Equal(frame.ExceptionHandlers[0].Handlers[0].HandlerStart!.Offset, result.NextOffset);
+        }
+
+        [Fact]
+        public void EndFinallyAfterUnhandledExceptionShouldExposeException()
+        {
+            var frame = GetMockFrame(nameof(TestClass.TryFinally));
+            
+            var stack = frame.ExceptionHandlerStack;          
+            stack.Push(frame.ExceptionHandlers[0]); // try-finally
+            var exceptionObject = GetMockException<Exception>();
+            stack.RegisterException(exceptionObject);
+
+            var result = stack.EndFinally();
+            Assert.False(result.IsSuccess);
+            Assert.Equal(exceptionObject, result.ExceptionObject);
+        }
+    }
+}

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/StateTransitionResolverTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/StateTransitionResolverTest.cs
@@ -75,29 +75,5 @@ namespace Echo.Platforms.AsmResolver.Tests
             }
         }
 
-        [Fact]
-        public void Switch()
-        {
-            var type = (TypeDefinition) _moduleFixture.MockModule.LookupMember(typeof(SimpleClass).MetadataToken);
-            var method = type.Methods.First(m => m.Name == nameof(SimpleClass.SwitchColor));
-            var body = method.CilMethodBody!;
-            var cfg = body.ConstructSymbolicFlowGraph(out var dfg);
-            
-            Assert.Equal(3, cfg.Entrypoint.ConditionalEdges.Count);
-            var dependencies = dfg.Nodes[body.Instructions.Last(i=>i.OpCode == CilOpCodes.Ldloc_1).Offset].VariableDependencies;
-            Assert.Equal(3, dependencies.First().Count);
-        }
-
-        [Fact]
-        public void Loop()
-        {
-            var type = (TypeDefinition) _moduleFixture.MockModule.LookupMember(typeof(SimpleClass).MetadataToken);
-            var method = type.Methods.First(m => m.Name == nameof(SimpleClass.Loop));
-            var body = method.CilMethodBody!;
-            var cfg = body.ConstructSymbolicFlowGraph(out var dfg);
-            
-            Assert.Equal(2, dfg.Nodes[body.Instructions[6].Offset].VariableDependencies.First().Count);
-            Assert.Equal(2, dfg.Nodes[body.Instructions[7].Offset].VariableDependencies.First().Count);
-        }
     }
 }

--- a/test/Platforms/Mocks/TestClass.cs
+++ b/test/Platforms/Mocks/TestClass.cs
@@ -129,7 +129,7 @@ namespace Mocks
                     throw new Exception("This is an handled exception.");
                 result = 1;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 result = 2;
             }
@@ -147,7 +147,7 @@ namespace Mocks
                     throw new Exception("This is an handled exception.");
                 result = 1;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 result = 2;
             }
@@ -173,11 +173,11 @@ namespace Mocks
                     _ => 1
                 };
             }
-            catch (IOException ex)
+            catch (IOException)
             {
                 result = 2;
             }
-            catch (WebException ex)
+            catch (WebException)
             {
                 result = 3;
             }
@@ -199,11 +199,11 @@ namespace Mocks
                     _ => 1
                 };
             }
-            catch (EndOfStreamException ex)
+            catch (EndOfStreamException)
             {
                 result = 2;
             }
-            catch (IOException ex)
+            catch (IOException)
             {
                 result = 3;
             }
@@ -225,11 +225,11 @@ namespace Mocks
                     _ => 1
                 };
             }
-            catch (IOException ex)
+            catch (IOException)
             {
                 result = 2;
             }
-            catch (WebException ex)
+            catch (WebException)
             {
                 result = 3;
             }
@@ -278,7 +278,7 @@ namespace Mocks
                     UnhandledException();
                 result = 1;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 result = 2;
             }

--- a/test/Platforms/Mocks/TestClass.cs
+++ b/test/Platforms/Mocks/TestClass.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Net;
 using InlineIL;
 
 namespace Mocks
@@ -11,26 +13,6 @@ namespace Mocks
         public static string GetConstantString() => "Hello, world!";
         public static string GetIsEvenString(int i) => i % 2 == 0 ? "even" : "odd";
         public static bool GetBoolean() => true;
-
-        public static void ExceptionHandler()
-        {
-            try
-            {
-                Console.WriteLine("Password:");
-                if (Console.ReadLine() == "MyPassword")
-                {
-                    Console.WriteLine("Amazing");
-                }
-                else
-                {
-                    Console.WriteLine("Nope");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-            }
-        }
 
         public static void NoLocalsNoArguments()
         {
@@ -115,6 +97,175 @@ namespace Mocks
         public static int DangerousMethod(int y)
         {
             return y + 100;
+        }
+        
+        public int UnhandledException() => throw new Exception("This is an unhandled exception.");
+
+        public int TryFinally(bool @throw)
+        {
+            int result = 0;
+            
+            try
+            {
+                if (@throw)
+                    throw new Exception("This is an unhandled exception.");
+                result++;
+            }
+            finally
+            {
+                result += 100;
+            }
+
+            return result;
+        }
+
+        public int TryCatch(bool @throw)
+        {
+            int result;
+            
+            try
+            {
+                if (@throw)
+                    throw new Exception("This is an handled exception.");
+                result = 1;
+            }
+            catch (Exception ex)
+            {
+                result = 2;
+            }
+
+            return result;   
+        }
+
+        public int TryCatchFinally(bool @throw)
+        {
+            int result = 0;
+
+            try
+            {
+                if (@throw)
+                    throw new Exception("This is an handled exception.");
+                result = 1;
+            }
+            catch (Exception ex)
+            {
+                result = 2;
+            }
+            finally
+            {
+                result += 100;
+            }
+
+            return result;   
+        }
+
+        public int TryCatchCatch(int exceptionType)
+        {
+            int result = 0;
+
+            try
+            {
+                result = exceptionType switch
+                {
+                    0 => throw new IOException("This is a handled IOException."),
+                    1 => throw new WebException("This is a handled WebException."),
+                    2 => throw new ArgumentException("This is an unhandled ArgumentException"),
+                    _ => 1
+                };
+            }
+            catch (IOException ex)
+            {
+                result = 2;
+            }
+            catch (WebException ex)
+            {
+                result = 3;
+            }
+
+            return result;   
+        }
+        
+        public int TryCatchSpecificAndGeneral(int exceptionType)
+        {
+            int result = 0;
+
+            try
+            {
+                result = exceptionType switch
+                {
+                    0 => throw new EndOfStreamException("This is a handled EndOfStreamException."),
+                    1 => throw new IOException("This is a handled IOException."),
+                    2 => throw new ArgumentException("This is an unhandled ArgumentException"),
+                    _ => 1
+                };
+            }
+            catch (EndOfStreamException ex)
+            {
+                result = 2;
+            }
+            catch (IOException ex)
+            {
+                result = 3;
+            }
+
+            return result;   
+        }
+
+        public int TryCatchCatchFinally(int exceptionType)
+        {
+            int result = 0;
+
+            try
+            {
+                result = exceptionType switch
+                {
+                    0 => throw new IOException("This is a handled IOException."),
+                    1 => throw new WebException("This is a handled WebException."),
+                    2 => throw new ArgumentException("This is an unhandled ArgumentException"),
+                    _ => 1
+                };
+            }
+            catch (IOException ex)
+            {
+                result = 2;
+            }
+            catch (WebException ex)
+            {
+                result = 3;
+            }
+            finally
+            {
+                result += 100;
+            }
+            
+            return result;
+        }
+
+        public int TryCatchFilters(int exceptionType)
+        {
+            int result = 0;
+
+            try
+            {
+                result = exceptionType switch
+                {
+                    0 => throw new IOException("This is handled exception 0"),
+                    1 => throw new IOException("This is handled exception 1"),
+                    2 => throw new IOException("This is unhandled exception 2"),
+                    3 => throw new ArgumentException("This is unhandled other exception"),
+                    _ => 1
+                };
+            }
+            catch (IOException ex) when (ex.Message.Contains("0"))
+            {
+                result = 2;
+            }
+            catch (IOException ex) when (ex.Message.Contains("1"))
+            {
+                result = 3;
+            }
+
+            return result;
         }
     }
 }

--- a/test/Platforms/Mocks/TestClass.cs
+++ b/test/Platforms/Mocks/TestClass.cs
@@ -99,9 +99,9 @@ namespace Mocks
             return y + 100;
         }
         
-        public int UnhandledException() => throw new Exception("This is an unhandled exception.");
+        public static int UnhandledException() => throw new Exception("This is an unhandled exception.");
 
-        public int TryFinally(bool @throw)
+        public static int TryFinally(bool @throw)
         {
             int result = 0;
             
@@ -119,7 +119,7 @@ namespace Mocks
             return result;
         }
 
-        public int TryCatch(bool @throw)
+        public static int TryCatch(bool @throw)
         {
             int result;
             
@@ -137,7 +137,7 @@ namespace Mocks
             return result;   
         }
 
-        public int TryCatchFinally(bool @throw)
+        public static int TryCatchFinally(bool @throw)
         {
             int result = 0;
 
@@ -156,10 +156,10 @@ namespace Mocks
                 result += 100;
             }
 
-            return result;   
+            return result;
         }
 
-        public int TryCatchCatch(int exceptionType)
+        public static int TryCatchCatch(int exceptionType)
         {
             int result = 0;
 
@@ -185,7 +185,7 @@ namespace Mocks
             return result;   
         }
         
-        public int TryCatchSpecificAndGeneral(int exceptionType)
+        public static int TryCatchSpecificAndGeneral(int exceptionType)
         {
             int result = 0;
 
@@ -194,7 +194,7 @@ namespace Mocks
                 result = exceptionType switch
                 {
                     0 => throw new EndOfStreamException("This is a handled EndOfStreamException."),
-                    1 => throw new IOException("This is a handled IOException."),
+                    1 => throw new FileNotFoundException("This is a handled IOException."),
                     2 => throw new ArgumentException("This is an unhandled ArgumentException"),
                     _ => 1
                 };
@@ -211,7 +211,7 @@ namespace Mocks
             return result;   
         }
 
-        public int TryCatchCatchFinally(int exceptionType)
+        public static int TryCatchCatchFinally(int exceptionType)
         {
             int result = 0;
 
@@ -241,7 +241,7 @@ namespace Mocks
             return result;
         }
 
-        public int TryCatchFilters(int exceptionType)
+        public static int TryCatchFilters(int exceptionType)
         {
             int result = 0;
 
@@ -249,20 +249,38 @@ namespace Mocks
             {
                 result = exceptionType switch
                 {
-                    0 => throw new IOException("This is handled exception 0"),
-                    1 => throw new IOException("This is handled exception 1"),
-                    2 => throw new IOException("This is unhandled exception 2"),
-                    3 => throw new ArgumentException("This is unhandled other exception"),
+                    0 => throw new IOException("0"),
+                    1 => throw new IOException("11"),
+                    2 => throw new IOException("222"),
+                    3 => throw new ArgumentException("3333"),
                     _ => 1
                 };
             }
-            catch (IOException ex) when (ex.Message.Contains("0"))
+            catch (IOException ex) when (ex.Message.Length == 1)
             {
                 result = 2;
             }
-            catch (IOException ex) when (ex.Message.Contains("1"))
+            catch (IOException ex) when (ex.Message.Length == 2)
             {
                 result = 3;
+            }
+
+            return result;
+        }
+
+        public static int CatchExceptionInChildMethod(bool @throw)
+        {
+            int result = 0;
+            
+            try
+            {
+                if (@throw)
+                    UnhandledException();
+                result = 1;
+            }
+            catch (Exception ex)
+            {
+                result = 2;
             }
 
             return result;


### PR DESCRIPTION
Includes:
- Add `ExceptionHandlerFrame` and `ExceptionHandlerStack` to call frames, implementing the exception handling mechanism.
- Add opcode handlers for `leave`, `leave.s`, `throw`, `rethrow`, `endfinally` and `endfilter`.
- Add `NativeMethodInvoker`.
- Add stack unwinding and exposing the exception object in `CilVirtualMachine` when the exception was kept unhandled.
- Bugfixes for various opcode handlers (`newobj`, `ldarg`, `starg`).
