### PR TITLE
Fix infinite loop for unary operator opcodes

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Arithmetic/UnaryOperatorHandlerBase.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/Arithmetic/UnaryOperatorHandlerBase.cs
@@ -6,10 +6,10 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Arithmetic
     /// <summary>
     /// Provides a base for unary operator instruction handlers.
     /// </summary>
-    public abstract class UnaryOperatorHandlerBase : ICilOpCodeHandler
+    public abstract class UnaryOperatorHandlerBase : FallThroughOpCodeHandler
     {
         /// <inheritdoc />
-        public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
         {
             var value = context.CurrentFrame.EvaluationStack.Pop();
             var result = Evaluate(context, instruction, value);
@@ -18,7 +18,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.Arithmetic
         }
 
         /// <summary>
-        /// Evaluates the unary operation on an arguments. 
+        /// Evaluates the unary operation on an argument.
         /// </summary>
         /// <param name="context">The context to evaluate the instruction in.</param>
         /// <param name="instruction">The instruction to dispatch and evaluate.</param>


### PR DESCRIPTION
`UnaryOperatorHandlerBase` does not increase the ProgramCounter so it will never progress past the current instruction.

```cs
var module = ModuleDefinition.FromModule(typeof(UnaryOperatorTestClass).Module);
var method = module.GetAllTypes().FirstOrDefault(x => x.Name == "UnaryOperatorTestClass")?.Methods.FirstOrDefault(x => x.Name == "UnaryOperatorTest");

var vm = new CilVirtualMachine(module, false);
vm.Call(method!, Array.Empty<BitVector>());
public static class UnaryOperatorTestClass
{
    public static bool UnaryOperatorTest()
    {
        var one = 1;
        var negated = -one;
        return negated == -1;
    }
}
```
Executing this will continuously execute the negate instruction and never progress past it.
To fix this, I just switched `UnaryOperatorHandlerBase` to implement `FallThroughOpCodeHandler`