### PR TITLE
Fix marshalling enums in CliMarshaller

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CliMarshaller.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CliMarshaller.cs
@@ -28,7 +28,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             switch (type.ElementType)
             {
-                case ElementType.Enum:
+                case ElementType.ValueType:
                     if (!_resolvedTypes.TryGetValue(type, out var definition))
                     {
                         definition = type.Resolve();
@@ -36,10 +36,13 @@ namespace Echo.Platforms.AsmResolver.Emulation
                             _resolvedTypes.Add(type, definition);
                     }
 
-                    if (definition?.GetEnumUnderlyingType() is not { } enumUnderlyingType)
+                    if (!definition?.IsEnum ?? true)
+                        return type;
+                    
+                    if (definition.GetEnumUnderlyingType() is not { } enumUnderlyingType)
                         throw new CilEmulatorException($"Could not resolve enum type {type.FullName}.");
                     
-                    return GetElementType(enumUnderlyingType);
+                    return enumUnderlyingType;
                 
                 default:
                     return type;

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CliMarshallerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CliMarshallerTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Echo.Memory;
+using Echo.Platforms.AsmResolver.Emulation;
+using Echo.Platforms.AsmResolver.Emulation.Stack;
+using Echo.Platforms.AsmResolver.Tests.Mock;
+using Mocks;
+using Xunit;
+
+namespace Echo.Platforms.AsmResolver.Tests.Emulation;
+
+public class CliMarshallerTest : IClassFixture<MockModuleFixture>
+{
+    private readonly MockModuleFixture _fixture;
+    private readonly ValueFactory _factory;
+    private readonly CliMarshaller _marshaller;
+
+    public CliMarshallerTest(MockModuleFixture fixture)
+    {
+        _fixture = fixture;
+        _factory = new ValueFactory(_fixture.MockModule, false);
+        _marshaller = new CliMarshaller(_factory);
+    }
+
+    [Fact]
+    public void MarshalEnumToStackShouldMarshalAsInteger()
+    {
+        var int32EnumType = _fixture.MockModule.TopLevelTypes.First(x => x.Name == nameof(Int32Enum));
+        var marshalledEnum = _marshaller.ToCliValue(new BitVector(0x1337), int32EnumType.ToTypeSignature());
+        
+        Assert.Equal(StackSlotTypeHint.Integer, marshalledEnum.TypeHint);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/Washi1337/Echo/issues/132

`ElementType.Enum` is only seen in custom attributes, which I don't think would ever be pushed to stack, so I removed that case and replaced it with `ElementType.ValueType` in `CliMarshaller.GetElementType()`
If you think I should add it back, just let me know :D

Also, enums can only have an underlying type of built-in integer types, so I removed the recursive call.