### PR TITLE
Emulator Threads

### DIFF
--- a/src/Core/Echo/Memory/VirtualMemory.cs
+++ b/src/Core/Echo/Memory/VirtualMemory.cs
@@ -49,12 +49,18 @@ namespace Echo.Memory
         /// <exception cref="ArgumentException">Occurs when the address was already in use.</exception>
         public void Map(long address, IMemorySpace space)
         {
+            if (space.AddressRange.Length == 0)
+                throw new ArgumentException("Cannot map an empty memory space.");
+            
             if (!AddressRange.Contains(address))
-                throw new ArgumentException($"Address {address:X8} does not fall within the virtual memory.");
+                throw new ArgumentException($"Address 0x{address:X8} does not fall within the virtual memory.");
+            
+            if (!AddressRange.Contains(address + space.AddressRange.Length - 1))
+                throw new ArgumentException($"Insufficient space available at address 0x{address:X8} to map {space.AddressRange.Length} bytes within the virtual memory.");
 
             int index = GetMemorySpaceIndex(address);
             if (index != -1)
-                throw new ArgumentException($"Address {address:X8} is already in use.");
+                throw new ArgumentException($"Address 0x{address:X8} is already in use.");
 
             // Insertion sort to ensure _spaces remains sorted.
             int i = 0;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
+using Echo.Memory;
+using Echo.Platforms.AsmResolver.Emulation.Dispatch;
+using Echo.Platforms.AsmResolver.Emulation.Stack;
+
+namespace Echo.Platforms.AsmResolver.Emulation
+{
+    /// <summary>
+    /// Represents a single execution thread in a virtualized .NET process.
+    /// </summary>
+    public class CilThread
+    {
+        private CilExecutionContext? _singleStepContext;
+
+        internal CilThread(CilVirtualMachine machine, CallStack callStack)
+        {
+            Machine = machine;
+            CallStack = callStack;
+        }
+
+        /// <summary>
+        /// Gets the parent machine the thread is running in.
+        /// </summary>
+        public CilVirtualMachine Machine
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the current state of the call stack.
+        /// </summary>
+        /// <remarks>
+        /// The call stack is also addressable from <see cref="Memory"/>.
+        /// </remarks>
+        public CallStack CallStack
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Runs the virtual machine until it halts.
+        /// </summary>
+        public void Run() => Run(CancellationToken.None);
+
+        /// <summary>
+        /// Runs the virtual machine until it halts.
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
+        public void Run(CancellationToken cancellationToken)
+        {
+            StepWhile(cancellationToken, context => !context.CurrentFrame.IsRoot);
+        }
+
+        /// <summary>
+        /// Calls the provided method in the context of the virtual machine.
+        /// </summary>
+        /// <param name="method">The method to call.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <returns>The return value, or <c>null</c> if the provided method does not return a value.</returns>
+        /// <remarks>
+        /// This method is blocking until the emulation of the call completes.
+        /// </remarks>
+        public BitVector? Call(IMethodDescriptor method, object[] arguments)
+        {
+            // Short circuit before we do expensive marshalling...
+            if (arguments.Length != method.Signature!.GetTotalParameterCount())
+                throw new TargetParameterCountException();
+
+            var marshalled = arguments.Select(x => Machine.ObjectMarshaller.ToBitVector(x)).ToArray();
+            return Call(method, CancellationToken.None, marshalled);
+        }
+
+        /// <summary>
+        /// Calls the provided method in the context of the virtual machine.
+        /// </summary>
+        /// <param name="method">The method to call.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <returns>The return value, or <c>null</c> if the provided method does not return a value.</returns>
+        /// <remarks>
+        /// This method is blocking until the emulation of the call completes.
+        /// </remarks>
+        public BitVector? Call(IMethodDescriptor method, BitVector[] arguments)
+        {
+            return Call(method, CancellationToken.None, arguments);
+        }
+
+        /// <summary>
+        /// Calls the provided method in the context of the virtual machine.
+        /// </summary>
+        /// <param name="method">The method to call.</param>
+        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <returns>The return value, or <c>null</c> if the provided method does not return a value.</returns>
+        /// <remarks>
+        /// This method is blocking until the emulation of the call completes or the emulation is canceled.
+        /// </remarks>
+        public BitVector? Call(IMethodDescriptor method, CancellationToken cancellationToken, BitVector[] arguments)
+        {
+            if (arguments.Length != method.Signature!.GetTotalParameterCount())
+                throw new TargetParameterCountException();
+
+            var pool = Machine.ValueFactory.BitVectorPool;
+
+            // Instantiate any generic types if available.
+            var context = GenericContext.FromMethod(method);
+            var signature = method.Signature.InstantiateGenericTypes(context);
+
+            // Set up callee frame.
+            var frame = CallStack.Push(method);
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                var slot = Machine.ValueFactory.Marshaller.ToCliValue(arguments[i], signature.ParameterTypes[i]);
+                frame.WriteArgument(i, slot.Contents);
+                pool.Return(slot.Contents);
+            }
+
+            // Run until we return.
+            StepOut(cancellationToken);
+
+            // If void, then we don't have anything else to do.
+            if (!signature.ReturnsValue)
+                return null;
+
+            // If we produced a return value, return a copy of it to the caller.
+            // As the return value may be a rented bit vector, we should copy it to avoid unwanted side-effects.
+            var callResult = CallStack.Peek().EvaluationStack.Pop(signature.ReturnType);
+            var result = callResult.Clone();
+            pool.Return(callResult);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Continues execution of the virtual machine while the provided predicate returns <c>true</c>.
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
+        /// <param name="condition">
+        /// A predicate that is evaluated on every step of the emulation, determining whether execution should continue.
+        /// </param>
+        public void StepWhile(CancellationToken cancellationToken, Predicate<CilExecutionContext> condition)
+        {
+            var context = new CilExecutionContext(this, cancellationToken);
+
+            do
+            {
+                Step(context);
+                cancellationToken.ThrowIfCancellationRequested();
+            } while (condition(context));
+        }
+
+        /// <summary>
+        /// Performs a single step in the virtual machine. If the current instruction performs a call, the emulation
+        /// is treated as a single instruction.
+        /// </summary>
+        public void StepOver() => StepOver(CancellationToken.None);
+
+        /// <summary>
+        /// Performs a single step in the virtual machine. If the current instruction performs a call, the emulation
+        /// is treated as a single instruction.
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
+        public void StepOver(CancellationToken cancellationToken)
+        {
+            int stackDepth = CallStack.Count;
+            StepWhile(cancellationToken, context => context.Thread.CallStack.Count > stackDepth);
+        }
+
+        /// <summary>
+        /// Continues execution of the virtual machine until the current call frame is popped from the stack. 
+        /// </summary>
+        public void StepOut() => StepOut(CancellationToken.None);
+
+        /// <summary>
+        /// Continues execution of the virtual machine until the current call frame is popped from the stack. 
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
+        public void StepOut(CancellationToken cancellationToken)
+        {
+            int stackDepth = CallStack.Count;
+            StepWhile(cancellationToken, context => context.Thread.CallStack.Count >= stackDepth);
+        }
+
+        /// <summary>
+        /// Performs a single step in the virtual machine.
+        /// </summary>
+        public void Step()
+        {
+            _singleStepContext ??= new CilExecutionContext(this, CancellationToken.None);
+            Step(_singleStepContext);
+        }
+
+        /// <summary>
+        /// Performs a single step in the virtual machine.
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
+        public void Step(CancellationToken cancellationToken) => Step(new CilExecutionContext(this, cancellationToken));
+
+        private void Step(CilExecutionContext context)
+        {
+            if (CallStack.Peek().IsRoot)
+                throw new CilEmulatorException("No method is currently being executed.");
+
+            var currentFrame = CallStack.Peek();
+            if (currentFrame.Body is not { } body)
+                throw new CilEmulatorException("Emulator only supports managed method bodies.");
+
+            // Determine the next instruction to dispatch.
+            int pc = currentFrame.ProgramCounter;
+            var instruction = body.Instructions.GetByOffset(pc);
+            if (instruction is null)
+                throw new CilEmulatorException($"Invalid program counter in {currentFrame}.");
+
+            // Are we entering any protected regions?
+            UpdateExceptionHandlerStack();
+
+            // Dispatch the instruction.
+            var result = Machine.Dispatcher.Dispatch(context, instruction);
+
+            if (!result.IsSuccess)
+            {
+                var exceptionObject = result.ExceptionObject;
+                if (exceptionObject.IsNull)
+                    throw new CilEmulatorException("A null exception object was thrown.");
+
+                // If there were any errors thrown after dispatching, it may trigger the execution of one of the
+                // exception handlers in the entire call stack.
+                if (!UnwindCallStack(exceptionObject))
+                    throw new EmulatedException(exceptionObject);
+            }
+        }
+
+        private void UpdateExceptionHandlerStack()
+        {
+            var currentFrame = CallStack.Peek();
+
+            int pc = currentFrame.ProgramCounter;
+            var availableHandlers = currentFrame.ExceptionHandlers;
+            var activeHandlers = currentFrame.ExceptionHandlerStack;
+
+            for (int i = 0; i < availableHandlers.Count; i++)
+            {
+                var handler = availableHandlers[i];
+                if (handler.ProtectedRange.Contains(pc) && handler.Enter() && !activeHandlers.Contains(handler))
+                    activeHandlers.Push(handler);
+            }
+        }
+
+        private bool UnwindCallStack(ObjectHandle exceptionObject)
+        {
+            while (!CallStack.Peek().IsRoot)
+            {
+                var currentFrame = CallStack.Peek();
+
+                var result = currentFrame.ExceptionHandlerStack.RegisterException(exceptionObject);
+                if (result.IsSuccess)
+                {
+                    // We found a handler that needs to be called. Jump to it.
+                    currentFrame.ProgramCounter = result.NextOffset;
+
+                    // Push the exception on the stack.
+                    currentFrame.EvaluationStack.Clear();
+                    currentFrame.EvaluationStack.Push(exceptionObject);
+
+                    return true;
+                }
+
+                CallStack.Pop();
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
@@ -22,6 +22,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             Machine = machine;
             CallStack = callStack;
+            IsAlive = true;
         }
 
         /// <summary>
@@ -41,6 +42,15 @@ namespace Echo.Platforms.AsmResolver.Emulation
         public CallStack CallStack
         {
             get;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the thread is alive and present in the parent machine.
+        /// </summary>
+        public bool IsAlive
+        {
+            get;
+            internal set;
         }
 
         /// <summary>
@@ -203,6 +213,9 @@ namespace Echo.Platforms.AsmResolver.Emulation
 
         private void Step(CilExecutionContext context)
         {
+            if (!IsAlive)
+                throw new CilEmulatorException("The thread is not alive.");
+            
             if (CallStack.Peek().IsRoot)
                 throw new CilEmulatorException("No method is currently being executed.");
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
@@ -162,7 +162,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
         /// </summary>
         /// <param name="stackSize">The amount of memory to allocate for the thread's stack.</param>
         /// <returns>The created thread.</returns>
-        public CilThread CreateThread(uint stackSize = 0x40000000U)
+        public CilThread CreateThread(uint stackSize = 0x0010_0000)
         {
             var stack = _callStackMemory.Allocate(stackSize);
             var thread = new CilThread(this, stack);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Linq;
-using System.Reflection;
-using System.Threading;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using AsmResolver.DotNet;
-using AsmResolver.DotNet.Signatures;
-using AsmResolver.PE.DotNet.Cil;
 using Echo.Memory;
 using Echo.Platforms.AsmResolver.Emulation.Dispatch;
 using Echo.Platforms.AsmResolver.Emulation.Heap;
@@ -19,7 +15,8 @@ namespace Echo.Platforms.AsmResolver.Emulation
     /// </summary>
     public class CilVirtualMachine
     {
-        private CilExecutionContext? _singleStepContext;
+        private readonly List<CilThread> _threads = new();
+        private readonly CallStackMemory _callStackMemory;
 
         /// <summary>
         /// Creates a new CIL virtual machine.
@@ -34,25 +31,26 @@ namespace Echo.Platforms.AsmResolver.Emulation
             ValueFactory = new ValueFactory(contextModule, is32Bit);
             ObjectMapMemory = new ObjectMapMemory(this, 0x1000_0000);
             ObjectMarshaller = new ObjectMarshaller(this);
-
+            
             if (is32Bit)
             {
                 Memory.Map(0x1000_0000, Heap = new ManagedObjectHeap(0x0100_0000, ValueFactory));
                 Memory.Map(0x6000_0000, ObjectMapMemory);
                 Memory.Map(0x7000_0000, StaticFields = new StaticFieldStorage(ValueFactory, 0x0100_0000));
                 Memory.Map(0x7100_0000, ValueFactory.ClrMockMemory);
-                Memory.Map(0x7fe0_0000, CallStack = new CallStack(0x10_0000, ValueFactory));
+                Memory.Map(0x7f00_0000, _callStackMemory = new CallStackMemory(0x100_0000, ValueFactory));
             }
             else
             {
                 Memory.Map(0x0000_0100_0000_0000, Heap = new ManagedObjectHeap(0x01000_0000, ValueFactory));
-                Memory.Map(0x0000_7ffe_0000_0000, ObjectMapMemory);
-                Memory.Map(0x0000_7fff_0000_0000, StaticFields = new StaticFieldStorage(ValueFactory, 0x1000_0000));
-                Memory.Map(0x0000_7fff_1000_0000, ValueFactory.ClrMockMemory);
-                Memory.Map(0x0000_7fff_8000_0000, CallStack = new CallStack(0x100_0000, ValueFactory));
+                Memory.Map(0x0000_7ffd_0000_0000, ObjectMapMemory);
+                Memory.Map(0x0000_7ffe_0000_0000, StaticFields = new StaticFieldStorage(ValueFactory, 0x1000_0000));
+                Memory.Map(0x0000_7ffe_1000_0000, ValueFactory.ClrMockMemory);
+                Memory.Map(0x0000_7ffe_8000_0000, _callStackMemory = new CallStackMemory(0x1000_0000, ValueFactory));
             }
 
             Dispatcher = new CilDispatcher();
+            Threads = new ReadOnlyCollection<CilThread>(_threads);
         }
 
         /// <summary>
@@ -83,17 +81,6 @@ namespace Echo.Platforms.AsmResolver.Emulation
         /// Gets the memory chunk responsible for storing static fields.
         /// </summary>
         public StaticFieldStorage StaticFields
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets the current state of the call stack.
-        /// </summary>
-        /// <remarks>
-        /// The call stack is also addressable from <see cref="Memory"/>.
-        /// </remarks>
-        public CallStack CallStack
         {
             get;
         }
@@ -161,239 +148,26 @@ namespace Echo.Platforms.AsmResolver.Emulation
             get;
             set;
         }
-        
+
         /// <summary>
-        /// Runs the virtual machine until it halts.
+        /// Gets a collection of threads that are currently active in the machine.
         /// </summary>
-        public void Run() => Run(CancellationToken.None);
-        
-        /// <summary>
-        /// Runs the virtual machine until it halts.
-        /// </summary>
-        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
-        public void Run(CancellationToken cancellationToken)
+        public IReadOnlyList<CilThread> Threads
         {
-            StepWhile(cancellationToken, context => !context.CurrentFrame.IsRoot);
+            get;
         }
 
         /// <summary>
-        /// Calls the provided method in the context of the virtual machine.
+        /// Creates a new thread in the machine.
         /// </summary>
-        /// <param name="method">The method to call.</param>
-        /// <param name="arguments">The arguments.</param>
-        /// <returns>The return value, or <c>null</c> if the provided method does not return a value.</returns>
-        /// <remarks>
-        /// This method is blocking until the emulation of the call completes.
-        /// </remarks>
-        public BitVector? Call(IMethodDescriptor method, object[] arguments)
+        /// <param name="stackSize">The amount of memory to allocate for the thread's stack.</param>
+        /// <returns>The created thread.</returns>
+        public CilThread CreateThread(uint stackSize = 0x40000000U)
         {
-            // Short circuit before we do expensive marshalling...
-            if (arguments.Length != method.Signature!.GetTotalParameterCount())
-                throw new TargetParameterCountException();
-            
-            var marshalled = arguments.Select(x => ObjectMarshaller.ToBitVector(x)).ToArray();
-            return Call(method, CancellationToken.None, marshalled);
+            var stack = _callStackMemory.Allocate(stackSize);
+            var thread = new CilThread(this, stack);
+            _threads.Add(thread);
+            return thread;
         }
-        
-        /// <summary>
-        /// Calls the provided method in the context of the virtual machine.
-        /// </summary>
-        /// <param name="method">The method to call.</param>
-        /// <param name="arguments">The arguments.</param>
-        /// <returns>The return value, or <c>null</c> if the provided method does not return a value.</returns>
-        /// <remarks>
-        /// This method is blocking until the emulation of the call completes.
-        /// </remarks>
-        public BitVector? Call(IMethodDescriptor method, BitVector[] arguments)
-        {
-            return Call(method, CancellationToken.None, arguments);
-        }
-
-        /// <summary>
-        /// Calls the provided method in the context of the virtual machine.
-        /// </summary>
-        /// <param name="method">The method to call.</param>
-        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
-        /// <param name="arguments">The arguments.</param>
-        /// <returns>The return value, or <c>null</c> if the provided method does not return a value.</returns>
-        /// <remarks>
-        /// This method is blocking until the emulation of the call completes or the emulation is canceled.
-        /// </remarks>
-        public BitVector? Call(IMethodDescriptor method, CancellationToken cancellationToken, BitVector[] arguments)
-        {
-            if (arguments.Length != method.Signature!.GetTotalParameterCount())
-                throw new TargetParameterCountException();
-
-            var pool = ValueFactory.BitVectorPool;
-            
-            // Instantiate any generic types if available.
-            var context = GenericContext.FromMethod(method);
-            var signature = method.Signature.InstantiateGenericTypes(context);
-
-            // Set up callee frame.
-            var frame = CallStack.Push(method);
-            for (int i = 0; i < arguments.Length; i++)
-            {
-                var slot = ValueFactory.Marshaller.ToCliValue(arguments[i], signature.ParameterTypes[i]);
-                frame.WriteArgument(i, slot.Contents);
-                pool.Return(slot.Contents);
-            }
-
-            // Run until we return.
-            StepOut(cancellationToken);
-
-            // If void, then we don't have anything else to do.
-            if (!signature.ReturnsValue)
-                return null;
-
-            // If we produced a return value, return a copy of it to the caller.
-            // As the return value may be a rented bit vector, we should copy it to avoid unwanted side-effects.
-            var callResult = CallStack.Peek().EvaluationStack.Pop(signature.ReturnType);
-            var result = callResult.Clone();
-            pool.Return(callResult);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Continues execution of the virtual machine while the provided predicate returns <c>true</c>.
-        /// </summary>
-        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
-        /// <param name="condition">
-        /// A predicate that is evaluated on every step of the emulation, determining whether execution should continue.
-        /// </param>
-        public void StepWhile(CancellationToken cancellationToken, Predicate<CilExecutionContext> condition)
-        {
-            var context = new CilExecutionContext(this, cancellationToken);
-
-            do
-            {
-                Step(context);
-                cancellationToken.ThrowIfCancellationRequested();
-            } while (condition(context));   
-        }
-
-        /// <summary>
-        /// Performs a single step in the virtual machine. If the current instruction performs a call, the emulation
-        /// is treated as a single instruction.
-        /// </summary>
-        public void StepOver() => StepOver(CancellationToken.None);
-
-        /// <summary>
-        /// Performs a single step in the virtual machine. If the current instruction performs a call, the emulation
-        /// is treated as a single instruction.
-        /// </summary>
-        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
-        public void StepOver(CancellationToken cancellationToken)
-        {
-            int stackDepth = CallStack.Count;
-            StepWhile(cancellationToken, context => context.Machine.CallStack.Count > stackDepth);
-        }
-
-        /// <summary>
-        /// Continues execution of the virtual machine until the current call frame is popped from the stack. 
-        /// </summary>
-        public void StepOut() => StepOut(CancellationToken.None);
-
-        /// <summary>
-        /// Continues execution of the virtual machine until the current call frame is popped from the stack. 
-        /// </summary>
-        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
-        public void StepOut(CancellationToken cancellationToken)
-        {
-            int stackDepth = CallStack.Count;
-            StepWhile(cancellationToken, context => context.Machine.CallStack.Count >= stackDepth);
-        }
-
-        /// <summary>
-        /// Performs a single step in the virtual machine.
-        /// </summary>
-        public void Step()
-        {
-            _singleStepContext ??= new CilExecutionContext(this, CancellationToken.None);
-            Step(_singleStepContext);
-        }
-
-        /// <summary>
-        /// Performs a single step in the virtual machine.
-        /// </summary>
-        /// <param name="cancellationToken">A token that can be used for canceling the emulation.</param>
-        public void Step(CancellationToken cancellationToken) => Step(new CilExecutionContext(this, cancellationToken));
-
-        private void Step(CilExecutionContext context)
-        {
-            if (CallStack.Peek().IsRoot)
-                throw new CilEmulatorException("No method is currently being executed.");
-
-            var currentFrame = CallStack.Peek();
-            if (currentFrame.Body is not { } body)
-                throw new CilEmulatorException("Emulator only supports managed method bodies.");
-            
-            // Determine the next instruction to dispatch.
-            int pc = currentFrame.ProgramCounter;
-            var instruction = body.Instructions.GetByOffset(pc);
-            if (instruction is null)
-                throw new CilEmulatorException($"Invalid program counter in {currentFrame}.");
-
-            // Are we entering any protected regions?
-            UpdateExceptionHandlerStack();
-
-            // Dispatch the instruction.
-            var result = Dispatcher.Dispatch(context, instruction);
-
-            if (!result.IsSuccess)
-            {
-                var exceptionObject = result.ExceptionObject;
-                if (exceptionObject.IsNull)
-                    throw new CilEmulatorException("A null exception object was thrown.");
-
-                // If there were any errors thrown after dispatching, it may trigger the execution of one of the
-                // exception handlers in the entire call stack.
-                if (!UnwindCallStack(exceptionObject))
-                    throw new EmulatedException(exceptionObject);
-            }
-        }
-
-        private void UpdateExceptionHandlerStack()
-        {
-            var currentFrame = CallStack.Peek();
-
-            int pc = currentFrame.ProgramCounter;
-            var availableHandlers = currentFrame.ExceptionHandlers;
-            var activeHandlers = currentFrame.ExceptionHandlerStack;
-
-            for (int i = 0; i < availableHandlers.Count; i++)
-            {
-                var handler = availableHandlers[i];
-                if (handler.ProtectedRange.Contains(pc) && handler.Enter() && !activeHandlers.Contains(handler))
-                    activeHandlers.Push(handler);
-            }
-        }
-
-        private bool UnwindCallStack(ObjectHandle exceptionObject)
-        {
-            while (!CallStack.Peek().IsRoot)
-            {
-                var currentFrame = CallStack.Peek();
-
-                var result = currentFrame.ExceptionHandlerStack.RegisterException(exceptionObject);
-                if (result.IsSuccess)
-                {
-                    // We found a handler that needs to be called. Jump to it.
-                    currentFrame.ProgramCounter = result.NextOffset;
-                    
-                    // Push the exception on the stack.
-                    currentFrame.EvaluationStack.Clear();
-                    currentFrame.EvaluationStack.Push(exceptionObject);
-
-                    return true;
-                }
-
-                CallStack.Pop();
-            }
-            
-            return false;
-        }
-
     }
 }

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/CilExecutionContext.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/CilExecutionContext.cs
@@ -13,24 +13,26 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch
         /// </summary>
         /// <param name="machine">The parent machine the instruction is executed on.</param>
         /// <param name="cancellationToken">A token used for canceling the emulation.</param>
-        public CilExecutionContext(CilVirtualMachine machine, CancellationToken cancellationToken)
+        public CilExecutionContext(CilThread thread, CancellationToken cancellationToken)
         {
-            Machine = machine;
+            Thread = thread;
             CancellationToken = cancellationToken;
         }
 
-        /// <summary>
-        /// Gets the parent machine the instruction is executed on.
-        /// </summary>
-        public CilVirtualMachine Machine
+        public CilThread Thread
         {
             get;
         }
 
         /// <summary>
+        /// Gets the parent machine the instruction is executed on.
+        /// </summary>
+        public CilVirtualMachine Machine => Thread.Machine;
+
+        /// <summary>
         /// Gets the current active stack frame.
         /// </summary>
-        public CallFrame CurrentFrame => Machine.CallStack.Peek();
+        public CallFrame CurrentFrame => Thread.CallStack.Peek();
 
         /// <summary>
         /// Gets a token used for canceling the emulation.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ControlFlow/RetHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ControlFlow/RetHandler.cs
@@ -13,7 +13,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ControlFlow
         /// <inheritdoc />
         public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
         {
-            var frame = context.Machine.CallStack.Pop();
+            var frame = context.Thread.CallStack.Pop();
             var genericContext = GenericContext.FromMethod(frame.Method);
             if (frame.Method.Signature!.ReturnsValue)
             {

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallHandlerBase.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallHandlerBase.cs
@@ -155,7 +155,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                     for (int i = 0; i < arguments.Count; i++)
                         frame.WriteArgument(i, arguments[i]);
 
-                    context.Machine.CallStack.Push(frame);
+                    context.Thread.CallStack.Push(frame);
                     return CilDispatchResult.Success();
 
                 case InvocationResultType.StepOver:

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallStack.cs
@@ -30,7 +30,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         /// </summary>
         /// <param name="maxSize">The maximum number of bytes the stack can hold.</param>
         /// <param name="factory">The service responsible for managing types.</param>
-        public CallStack(int maxSize, ValueFactory factory)
+        public CallStack(uint maxSize, ValueFactory factory)
         {
             _factory = factory;
             AddressRange = new AddressRange(0, maxSize);

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallStackMemory.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallStackMemory.cs
@@ -1,0 +1,56 @@
+using System;
+using Echo.Memory;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Stack
+{
+    internal class CallStackMemory : IMemorySpace
+    {
+        private readonly VirtualMemory _mapping;
+        private readonly ValueFactory _factory;
+
+        public CallStackMemory(uint totalSize, ValueFactory factory)
+        {
+            _mapping = new VirtualMemory(totalSize);
+            _factory = factory;
+        }
+
+        /// <inheritdoc />
+        public AddressRange AddressRange => _mapping.AddressRange;
+
+        /// <inheritdoc />
+        public bool IsValidAddress(long address) => _mapping.IsValidAddress(address);
+
+        /// <inheritdoc />
+        public void Rebase(long baseAddress) => _mapping.Rebase(baseAddress);
+
+        /// <inheritdoc />
+        public void Read(long address, BitVectorSpan buffer) => _mapping.Read(address, buffer);
+
+        /// <inheritdoc />
+        public void Write(long address, BitVectorSpan buffer) => _mapping.Write(address, buffer);
+
+        /// <inheritdoc />
+        public void Write(long address, ReadOnlySpan<byte> buffer) => _mapping.Write(address, buffer);
+
+        public CallStack Allocate(uint size)
+        {
+            var result = new CallStack(size, _factory);
+
+            long last = AddressRange.Start;
+            foreach (var range in _mapping.GetMappedRanges())
+            {
+                long available = last - range.Start;
+                if (available >= size)
+                    break;
+            
+                last = range.End;
+            }
+
+            _mapping.Map(last, result);
+        
+            return result;
+        }
+
+        public void Free(CallStack stack) => _mapping.Unmap(stack.AddressRange.Start);
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallStackMemory.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallStackMemory.cs
@@ -45,9 +45,8 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
             
                 last = range.End;
             }
-
+            
             _mapping.Map(last, result);
-        
             return result;
         }
 

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CilVirtualMachineTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CilVirtualMachineTest.cs
@@ -38,6 +38,21 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation
         }
 
         [Fact]
+        public void CreateSingleThread()
+        {
+            Assert.Contains(_mainThread, _vm.Threads);
+        }
+
+        [Fact]
+        public void CreateSecondaryThread()
+        {
+            var thread = _vm.CreateThread();
+            Assert.Contains(_mainThread, _vm.Threads);
+            Assert.False(thread.CallStack.AddressRange.Contains(_mainThread.CallStack.AddressRange.Start));
+            Assert.False(thread.CallStack.AddressRange.Contains(_mainThread.CallStack.AddressRange.End - 1));
+        }
+
+        [Fact]
         public void SingleStep()
         {
             // Prepare dummy method.

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/CilDispatcherTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/CilDispatcherTest.cs
@@ -29,9 +29,10 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch
             body.Instructions.Add(CilOpCodes.Ret);
 
             var vm = new CilVirtualMachine(fixture.MockModule, false);
-            vm.CallStack.Push(dummyMethod);
+            var thread = vm.CreateThread();
+            thread.CallStack.Push(dummyMethod);
 
-            _context = new CilExecutionContext(vm, CancellationToken.None);
+            _context = new CilExecutionContext(thread, CancellationToken.None);
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/CilOpCodeHandlerTestBase.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/CilOpCodeHandlerTestBase.cs
@@ -26,9 +26,10 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch
             body.Instructions.Add(CilOpCodes.Ret);
             
             var vm = new CilVirtualMachine(fixture.MockModule, false);
-            vm.CallStack.Push(dummyMethod);
+            var thread = vm.CreateThread();
+            thread.CallStack.Push(dummyMethod);
             
-            Context = new CilExecutionContext(vm, CancellationToken.None);
+            Context = new CilExecutionContext(thread, CancellationToken.None);
             Dispatcher = new CilDispatcher();
         }
 

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ControlFlow/RetHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ControlFlow/RetHandlerTest.cs
@@ -18,13 +18,13 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ControlFlow
         [Fact]
         public void RetFromVoidShouldPopFromCallStack()
         {
-            int currentFrameCount = Context.Machine.CallStack.Count;
+            int currentFrameCount = Context.Thread.CallStack.Count;
 
             var instruction = new CilInstruction(CilOpCodes.Ret);
             var result = Dispatcher.Dispatch(Context, instruction);
             
             Assert.True(result.IsSuccess);
-            Assert.Equal(currentFrameCount - 1, Context.Machine.CallStack.Count);
+            Assert.Equal(currentFrameCount - 1, Context.Thread.CallStack.Count);
         }
         
         [Fact]
@@ -32,7 +32,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ControlFlow
         {
             var method = new MethodDefinition("Dummy", MethodAttributes.Static,
                 MethodSignature.CreateStatic(ModuleFixture.MockModule.CorLibTypeFactory.Int32));
-            var frame = Context.Machine.CallStack.Push(method);
+            var frame = Context.Thread.CallStack.Push(method);
             frame.EvaluationStack.Push(new StackSlot(0x0123456789abcdef, StackSlotTypeHint.Integer));
             
             var calleeFrame = Context.CurrentFrame;

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CallHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CallHandlerTest.cs
@@ -162,7 +162,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
         {
             var method = new MethodDefinition("Dummy", MethodAttributes.Static,
                 MethodSignature.CreateStatic(ModuleFixture.MockModule.CorLibTypeFactory.Int32));
-            var frame = Context.Machine.CallStack.Push(method);
+            var frame = Context.Thread.CallStack.Push(method);
             frame.EvaluationStack.Push(new StackSlot(0x1337, StackSlotTypeHint.Integer));
             
             var calleeFrame = Context.CurrentFrame;

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CastHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CastHandlerTest.cs
@@ -195,7 +195,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
 
             var methodSpecification = genericMethod.MakeGenericInstanceMethod(ModuleFixture.MockModule.CorLibTypeFactory.Int16);
 
-            Context.Machine.CallStack.Push(methodSpecification);
+            Context.Thread.CallStack.Push(methodSpecification);
 
             var value = 32000;
 
@@ -225,7 +225,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
 
             var methodSpecification = genericMethod.MakeGenericInstanceMethod(ModuleFixture.MockModule.CorLibTypeFactory.Int32);
 
-            Context.Machine.CallStack.Push(methodSpecification);
+            Context.Thread.CallStack.Push(methodSpecification);
 
             var value = 214000000;
 
@@ -254,7 +254,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
 
             var methodSpecification = genericMethod.MakeGenericInstanceMethod(ModuleFixture.MockModule.CorLibTypeFactory.Int64);
 
-            Context.Machine.CallStack.Push(methodSpecification);
+            Context.Thread.CallStack.Push(methodSpecification);
 
             var value = 922000000000000000L;
 

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdFldHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdFldHandlerTest.cs
@@ -114,7 +114,7 @@ public class LdFldHandlerTest : CilOpCodeHandlerTestBase
             LocalVariables = {new CilLocalVariable(structType.ToTypeSignature())}
         };
 
-        Context.Machine.CallStack.Push(method);
+        Context.Thread.CallStack.Push(method);
 
         // Initialize variable with field set to 1337. 
         var instance = factory.CreateValue(structType.ToTypeSignature(), true);

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdFldaHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/LdFldaHandlerTest.cs
@@ -60,7 +60,7 @@ public class LdFldaHandlerTest : CilOpCodeHandlerTestBase
             LocalVariables = {new CilLocalVariable(structType.ToTypeSignature())}
         };
 
-        Context.Machine.CallStack.Push(method);
+        Context.Thread.CallStack.Push(method);
         
         // Push address to struct.
         var stack = Context.CurrentFrame.EvaluationStack;

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/StFldHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/StFldHandlerTest.cs
@@ -87,7 +87,7 @@ public class StFldHandlerTest : CilOpCodeHandlerTestBase
             LocalVariables = {new CilLocalVariable(structType.ToTypeSignature())}
         };
 
-        Context.Machine.CallStack.Push(method);
+        Context.Thread.CallStack.Push(method);
         
         // Push address to struct.
         var stack = Context.CurrentFrame.EvaluationStack;

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Variables/ArgumentsTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Variables/ArgumentsTest.cs
@@ -18,7 +18,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Variables
         {
         }
         
-          private void PrepareMethodWithArgument(int localCount, TypeSignature localType)
+        private void PrepareMethodWithArgument(int localCount, TypeSignature localType)
         {
             var factory = ModuleFixture.MockModule.CorLibTypeFactory;
             var method = new MethodDefinition("DummyMethod", MethodAttributes.Static,
@@ -31,7 +31,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Variables
             var body = new CilMethodBody(method);
             method.CilMethodBody = body;
 
-            Context.Machine.CallStack.Push(method);
+            Context.Thread.CallStack.Push(method);
         }
 
         [Theory]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Variables/LocalsTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/Variables/LocalsTest.cs
@@ -29,7 +29,7 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.Variables
                 body.LocalVariables.Add(new CilLocalVariable(localType));
             method.CilMethodBody = body;
 
-            Context.Machine.CallStack.Push(method);
+            Context.Thread.CallStack.Push(method);
         }
 
         [Theory]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Invocation/MethodInvokerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Invocation/MethodInvokerTest.cs
@@ -22,8 +22,9 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Invocation
             _fixture = fixture;
 
             var machine = new CilVirtualMachine(fixture.MockModule, false);
-            _context = new CilExecutionContext(machine, CancellationToken.None);
-            _context.Machine.CallStack.Push(fixture.MockModule.GetOrCreateModuleConstructor());
+            var thread = machine.CreateThread();
+            _context = new CilExecutionContext(thread, CancellationToken.None);
+            _context.Thread.CallStack.Push(fixture.MockModule.GetOrCreateModuleConstructor());
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerFrameTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerFrameTest.cs
@@ -15,16 +15,18 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
     {
         private readonly MockModuleFixture _fixture;
         private readonly CilVirtualMachine _vm;
+        private readonly CilThread _mainThread;
 
         public ExceptionHandlerFrameTest(MockModuleFixture fixture)
         {
             _fixture = fixture;
             _vm = new CilVirtualMachine(_fixture.MockModule, false);
+            _mainThread = _vm.CreateThread();
         }
 
         private CallFrame GetMockFrame(string methodName)
         {
-            return _vm.CallStack.Push(_fixture.GetTestMethod(methodName));
+            return _mainThread.CallStack.Push(_fixture.GetTestMethod(methodName));
         }
 
         [Fact]

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Stack/ExceptionHandlerStackTest.cs
@@ -20,16 +20,18 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Stack
     {
         private readonly MockModuleFixture _fixture;
         private readonly CilVirtualMachine _vm;
+        private readonly CilThread _mainThread;
 
         public ExceptionHandlerStackTest(MockModuleFixture fixture)
         {
             _fixture = fixture;
             _vm = new CilVirtualMachine(_fixture.MockModule, false);
+            _mainThread = _vm.CreateThread();
         }
 
         private CallFrame GetMockFrame(string methodName)
         {
-            return _vm.CallStack.Push(_fixture.GetTestMethod(methodName));
+            return _mainThread.CallStack.Push(_fixture.GetTestMethod(methodName));
         }
 
         private ObjectHandle GetMockException(Type type)


### PR DESCRIPTION
- Introduces the concept of multiple threads active in a single emulated CIL machine.
- Moves many of the executive functions of `CilVirtualMachine` such as `Step` and `Call` into `CilThread`. A new (main) thread now has to be started first to start emulated code using the `CilVirtualMachine::CreateThread()` method.