### PR TITLE
Add debugger display proxies for various primitives in emulator

### DIFF
--- a/src/Core/Echo/Memory/BitVector.cs
+++ b/src/Core/Echo/Memory/BitVector.cs
@@ -8,7 +8,8 @@ namespace Echo.Memory
     /// Represents an array of bits for which the concrete may be known or unknown, and can be reinterpreted as
     /// different value types, and operated on using the different semantics of these types.
     /// </summary>
-    [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+    // [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+    [DebuggerTypeProxy(typeof(BitVectorSpan))]
     public class BitVector : ICloneable
     {
         /// <summary>
@@ -51,6 +52,15 @@ namespace Echo.Memory
         {
             Bits = bits;
             KnownMask = knownMask;
+        }
+        
+        /// <summary>
+        /// Copies a span into a new bit vector.
+        /// </summary>
+        /// <param name="span">The span to copy.</param>
+        public BitVector(BitVectorSpan span)
+            : this(span.Bits.ToArray(), span.KnownMask.ToArray())
+        {
         }
         
         /// <summary>

--- a/src/Core/Echo/Memory/BitVector.cs
+++ b/src/Core/Echo/Memory/BitVector.cs
@@ -8,7 +8,6 @@ namespace Echo.Memory
     /// Represents an array of bits for which the concrete may be known or unknown, and can be reinterpreted as
     /// different value types, and operated on using the different semantics of these types.
     /// </summary>
-    // [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
     [DebuggerTypeProxy(typeof(BitVectorSpan))]
     public class BitVector : ICloneable
     {
@@ -266,10 +265,6 @@ namespace Echo.Memory
         {
             get;
         }
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal string DebuggerDisplay => AsSpan().DebuggerDisplay;
         
         /// <summary>
         /// Gets the number of bits stored in the bit vector.

--- a/src/Core/Echo/Memory/BitVectorSpan.cs
+++ b/src/Core/Echo/Memory/BitVectorSpan.cs
@@ -17,7 +17,16 @@ namespace Echo.Memory
         private static StringBuilder? _builder;
         
         [ThreadStatic]
-        private static List<BitVector?>? _temporaryVectors; 
+        private static List<BitVector?>? _temporaryVectors;
+
+        /// <summary>
+        /// Creates a new span around an existing bitvector.
+        /// </summary>
+        /// <param name="vector">The vector to span.</param>
+        public BitVectorSpan(BitVector vector)
+            : this(vector.Bits, vector.KnownMask)
+        {
+        }
 
         /// <summary>
         /// Creates a new span around a pair of bits and a known bit mask.
@@ -349,6 +358,11 @@ namespace Echo.Memory
 
             return _builder.ToString();
         }
+
+        /// <summary>
+        /// Copies the span into a new bit vector.
+        /// </summary>
+        public BitVector ToVector() => new(this);
         
         private void AssertSameBitSize(BitVectorSpan other)
         {
@@ -398,7 +412,7 @@ namespace Echo.Memory
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             // Since this is a ref struct, it will
             // never equal any reference type

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectHandle.DebugProxy.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ObjectHandle.DebugProxy.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
+
+namespace Echo.Platforms.AsmResolver.Emulation;
+
+[DebuggerTypeProxy(typeof(DebuggerProxy))]
+public readonly partial struct ObjectHandle
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private object? Tag
+    {
+        get
+        {
+            if (IsNull)
+                return null;
+
+            try
+            {
+                return GetObjectType();
+            }
+            catch
+            {
+                return "<invalid>";
+            }
+        }
+    }
+
+    private sealed class DebuggerProxy
+    {
+        private readonly ObjectHandle _handle;
+
+        public DebuggerProxy(ObjectHandle handle)
+        {
+            _handle = handle;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<object, object>[] Items
+        {
+            get
+            {
+                if (_handle.IsNull)
+                    return Array.Empty<KeyValuePair<object, object>>();
+
+                var type = _handle.GetObjectType().ToTypeSignature();
+
+                return type switch
+                {
+                    CorLibTypeSignature {ElementType: ElementType.String} => GetStringValue(),
+                    SzArrayTypeSignature arrayType => GetArrayValues(arrayType),
+                    _ => GetObjectFieldValues(type)
+                };
+            }
+        }
+
+        private KeyValuePair<object, object>[] GetStringValue()
+        {
+            // We cannot infer the string data if we don't know its length.
+            if (!_handle.ReadStringLength().IsFullyKnown)
+                return Array.Empty<KeyValuePair<object, object>>();
+
+            // Read and stringify the data.
+            var data = _handle.ReadStringData();
+            char[] result = new char[data.ByteCount / 2];
+            for (int i = 0; i < result.Length; i++)
+            {
+                var c = data.AsSpan(i * 8 * sizeof(char), 8 * sizeof(char));
+                result[i] = c.IsFullyKnown
+                    ? (char) c.U16
+                    : '?';
+            }
+            
+            return new[] {new KeyValuePair<object, object>(0, new string(result))};
+        }
+
+        private KeyValuePair<object, object>[] GetArrayValues(SzArrayTypeSignature type)
+        {
+            // We cannot infer the array data if we don't know its length.
+            var length = _handle.ReadArrayLength();
+            if (!length.IsFullyKnown)
+                return Array.Empty<KeyValuePair<object, object>>();
+
+            var elementType = type.BaseType;
+
+            // Collect all elements.
+            var result = new KeyValuePair<object, object>[length.AsSpan().I32];
+            for (int i = 0; i < result.Length; i++)
+            {
+                var element = _handle.ReadArrayElement(elementType, i);
+                result[i] = new KeyValuePair<object, object>(i, element);
+            }
+
+            return result;
+        }
+
+        private KeyValuePair<object, object>[] GetObjectFieldValues(TypeSignature type)
+        {
+            // We need to resolve the type to know which fields to include.
+            var definition = type.Resolve();
+            if (definition is null)
+                return Array.Empty<KeyValuePair<object, object>>();
+
+            // Collect all fields and their values.
+            var result = new List<KeyValuePair<object, object>>();
+            for (int i = 0; i < definition.Fields.Count; i++)
+            {
+                var field = definition.Fields[i];
+                if (field.IsStatic)
+                    continue;
+
+                result.Add(new KeyValuePair<object, object>(field, _handle.ReadField(field)));
+            }
+
+            return result.ToArray();
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallFrame.DebugProxy.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/CallFrame.DebugProxy.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.DotNet.Collections;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Stack;
+
+[DebuggerTypeProxy(typeof(DebuggerProxy))]
+public partial class CallFrame
+{
+    private sealed class DebuggerProxy
+    {
+        private readonly CallFrame _frame;
+
+        public DebuggerProxy(CallFrame frame)
+        {
+            _frame = frame;
+        }
+
+        public IMethodDescriptor Method => _frame.Method;
+
+        public int ProgramCounter => _frame.ProgramCounter;
+
+        public EvaluationStack EvaluationStack => _frame.EvaluationStack;
+
+        public ExceptionHandlerStack ExceptionHandlerStack => _frame.ExceptionHandlerStack;
+
+        public KeyValuePair<Parameter, object>[] Arguments
+        {
+            get
+            {
+                // Verify we have access to everything.
+                if (_frame is not {Body.Owner.Parameters: { } parameters, Method.Signature: { } signature})
+                    return Array.Empty<KeyValuePair<Parameter, object>>();
+
+                // Verify count.
+                int count = signature.GetTotalParameterCount();
+                if (count == 0)
+                    return Array.Empty<KeyValuePair<Parameter, object>>();
+
+                // Read all their values.
+                var result = new KeyValuePair<Parameter, object>[count];
+                for (int i = 0; i < result.Length; i++)
+                {
+                    result[i] = new KeyValuePair<Parameter, object>(
+                        parameters.GetBySignatureIndex(i),
+                        _frame.ReadArgument(i)
+                    );
+                }
+
+                return result;
+            }
+        }
+
+        public KeyValuePair<CilLocalVariable, object>[] Locals
+        {
+            get
+            {
+                // Verify locals exist.
+                if (_frame is not {Body.LocalVariables: {} locals} || locals.Count == 0)
+                    return Array.Empty<KeyValuePair<CilLocalVariable, object>>();
+                
+                // Read all their values.
+                var result = new KeyValuePair<CilLocalVariable, object>[locals.Count];
+                for (int i = 0; i < result.Length; i++)
+                    result[i] = new KeyValuePair<CilLocalVariable, object>(locals[i], _frame.ReadLocal(i));
+                
+                return result;
+            }
+        }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/EvaluationStack.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Stack/EvaluationStack.cs
@@ -8,15 +8,18 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
     /// </summary>
     public class EvaluationStack : IndexableStack<StackSlot>
     {
-        private readonly ValueFactory _factory;
-
         /// <summary>
         /// Creates a new evaluation stack.
         /// </summary>
         /// <param name="factory">The value factory to use.</param>
         public EvaluationStack(ValueFactory factory)
         {
-            _factory = factory;
+            Factory = factory;
+        }
+
+        internal ValueFactory Factory
+        {
+            get;
         }
 
         /// <summary>
@@ -25,10 +28,10 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         /// <param name="value">The handle to push.</param>
         public void Push(ObjectHandle value)
         {
-            var vector = _factory.RentNativeInteger(value.Address);
-            Push(vector, _factory.ContextModule.CorLibTypeFactory.Object, true);
+            var vector = Factory.RentNativeInteger(value.Address);
+            Push(vector, Factory.ContextModule.CorLibTypeFactory.Object, true);
         }
-        
+
         /// <summary>
         /// Marshals the provided bitvector into a stack slot, and pushes it onto the stack.
         /// </summary>
@@ -37,7 +40,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         /// <returns>The stack slot that was created.</returns>
         public void Push(BitVectorSpan value, TypeSignature originalType)
         {
-            var vector = _factory.BitVectorPool.Rent(value.Count, false);
+            var vector = Factory.BitVectorPool.Rent(value.Count, false);
             vector.AsSpan().Write(value);
             Push(vector, originalType, true);
         }
@@ -62,10 +65,10 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         /// <returns>The stack slot that was created.</returns>
         public void Push(BitVector value, TypeSignature originalType, bool releaseBitVector)
         {
-            var marshalled = _factory.Marshaller.ToCliValue(value, originalType);
+            var marshalled = Factory.Marshaller.ToCliValue(value, originalType);
             
             if (releaseBitVector)
-                _factory.BitVectorPool.Return(value);
+                Factory.BitVectorPool.Return(value);
             
             Push(marshalled);
         }
@@ -79,8 +82,8 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         {
             var slot = Pop();
             
-            var marshalled = _factory.Marshaller.FromCliValue(slot, targetType);
-            _factory.BitVectorPool.Return(slot.Contents);
+            var marshalled = Factory.Marshaller.FromCliValue(slot, targetType);
+            Factory.BitVectorPool.Return(slot.Contents);
             
             return marshalled;
         }
@@ -89,7 +92,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Stack
         public override void Clear()
         {
             for (int i = 0; i < Count; i++)
-                _factory.BitVectorPool.Return(this[i].Contents);
+                Factory.BitVectorPool.Return(this[i].Contents);
 
             base.Clear();
         }


### PR DESCRIPTION
Adds IDE debugger displays for the following:

- `BitVector`, displayed as a `BitVectorSpan` for easy interpretation of primitives.
- `ObjectHandle`, display changes depending on type behind address. Supported types are:
   - String
   - SzArray
   - Reference types
- `CallFrame`, enriched with easy accessible views for:
   - Locals
   - Arguments 
