### PR TITLE
Emulated Type Initializers

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
@@ -289,7 +289,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
 
                 // If the exception happened in a .cctor, register it and wrap it in a type initialization error.
                 if (currentFrame.Body?.Owner is { IsConstructor: true, IsStatic: true, DeclaringType: {} type })
-                    exceptionObject = Machine.TypeManager.RegisterTypeInitializationException(type, exceptionObject);
+                    exceptionObject = Machine.TypeManager.RegisterInitializationException(type, exceptionObject);
 
                 var result = currentFrame.ExceptionHandlerStack.RegisterException(exceptionObject);
                 if (result.IsSuccess)

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilThread.cs
@@ -260,7 +260,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
 
                 // If there were any errors thrown after dispatching, it may trigger the execution of one of the
                 // exception handlers in the entire call stack.
-                if (!UnwindCallStack(exceptionObject))
+                if (!UnwindCallStack(ref exceptionObject))
                     throw new EmulatedException(exceptionObject);
             }
         }
@@ -281,11 +281,15 @@ namespace Echo.Platforms.AsmResolver.Emulation
             }
         }
 
-        private bool UnwindCallStack(ObjectHandle exceptionObject)
+        private bool UnwindCallStack(ref ObjectHandle exceptionObject)
         {
             while (!CallStack.Peek().IsRoot)
             {
                 var currentFrame = CallStack.Peek();
+
+                // If the exception happened in a .cctor, register it and wrap it in a type initialization error.
+                if (currentFrame.Body?.Owner is { IsConstructor: true, IsStatic: true, DeclaringType: {} type })
+                    exceptionObject = Machine.TypeManager.RegisterTypeInitializationException(type, exceptionObject);
 
                 var result = currentFrame.ExceptionHandlerStack.RegisterException(exceptionObject);
                 if (result.IsSuccess)

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/CilVirtualMachine.cs
@@ -62,6 +62,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
             }
 
             Dispatcher = new CilDispatcher();
+            TypeManager = new RuntimeTypeManager(this);
             Threads = new ReadOnlyCollection<CilThread>(_threads);
         }
 
@@ -151,6 +152,15 @@ namespace Echo.Platforms.AsmResolver.Emulation
             get;
             set;
         } = DefaultInvokers.ReturnUnknown;
+
+        /// <summary>
+        /// Gets the service that is responsible for the initialization and management of runtime types residing in
+        /// the virtual machine.
+        /// </summary>
+        public RuntimeTypeManager TypeManager
+        {
+            get;
+        }
 
         /// <summary>
         /// Gets or sets the service that is responsible for resolving unknown values on the stack in critical moments.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallHandlerBase.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallHandlerBase.cs
@@ -156,6 +156,16 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                         frame.WriteArgument(i, arguments[i]);
 
                     context.Thread.CallStack.Push(frame);
+
+                    // Ensure type initializer is called for declaring type when necessary.
+                    // TODO: Handle `beforefieldinit` flag.
+                    if (method.DeclaringType is { } declaringType)
+                    {
+                        return context.Machine.TypeManager
+                            .HandleInitialization(context.Thread, declaringType)
+                            .ToDispatchResult();
+                    }
+                    
                     return CilDispatchResult.Success();
 
                 case InvocationResultType.StepOver:

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/FieldOpCodeHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/FieldOpCodeHandler.cs
@@ -1,0 +1,47 @@
+using AsmResolver.DotNet;
+using AsmResolver.PE.DotNet.Cil;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel;
+
+/// <summary>
+/// Represents a handler that handles opcodes related to field access.
+/// </summary>
+public abstract class FieldOpCodeHandler : ICilOpCodeHandler
+{
+    /// <inheritdoc />
+    public CilDispatchResult Dispatch(CilExecutionContext context, CilInstruction instruction)
+    {
+        var field = (IFieldDescriptor) instruction.Operand!;
+        
+        // Ensure the enclosing type is initialized in the runtime.
+        if (field.DeclaringType is { } declaringType)
+        {
+            var initResult = context.Machine.TypeManager.HandleInitialization(context.Thread, declaringType);
+            if (!initResult.IsNoAction)
+                return initResult.ToDispatchResult();
+        }
+
+        // Handle the actual field operation.
+        var dispatchResult = DispatchInternal(context, instruction, field);
+        
+        // We are not inheriting from FallThroughOpCodeHandler because of the type initialization.
+        // This means we need to manually increase the PC on success.
+        if (dispatchResult.IsSuccess)
+            context.CurrentFrame.ProgramCounter += instruction.Size;
+
+        return dispatchResult;
+    }
+
+    /// <summary>
+    /// Handles the actual operation on the field.
+    /// </summary>
+    /// <param name="context">The context to evaluate the instruction in.</param>
+    /// <param name="instruction">The instruction to dispatch and evaluate.</param>
+    /// <param name="field">The field to perform the operation on.</param>
+    /// <returns>The dispatching result.</returns>
+    protected abstract CilDispatchResult DispatchInternal(
+        CilExecutionContext context,
+        CilInstruction instruction,
+        IFieldDescriptor field
+    );
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFldHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFldHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using AsmResolver.DotNet;
 using AsmResolver.PE.DotNet.Cil;
-using Echo.Memory;
 using Echo.Platforms.AsmResolver.Emulation.Stack;
 
 namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
@@ -10,15 +9,17 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// Implements a CIL instruction handler for <c>ldfld</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Ldfld)]
-    public class LdFldHandler : FallThroughOpCodeHandler
+    public class LdFldHandler : FieldOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(
+            CilExecutionContext context, 
+            CilInstruction instruction, 
+            IFieldDescriptor field)
         {
             var stack = context.CurrentFrame.EvaluationStack;
             var factory = context.Machine.ValueFactory;
             
-            var field = (IFieldDescriptor) instruction.Operand!;
             var instance = stack.Pop();
 
             try

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFldaHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdFldaHandler.cs
@@ -9,15 +9,17 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// Implements a CIL instruction handler for <c>ldflda</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Ldflda)]
-    public class LdFldaHandler : FallThroughOpCodeHandler
+    public class LdFldaHandler : FieldOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(
+            CilExecutionContext context, 
+            CilInstruction instruction, 
+            IFieldDescriptor field)
         {
             var stack = context.CurrentFrame.EvaluationStack;
             var factory = context.Machine.ValueFactory;
             
-            var field = (IFieldDescriptor) instruction.Operand!;
             var instance = stack.Pop();
             var result = context.Machine.ValueFactory.RentNativeInteger(false);
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdsFldHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdsFldHandler.cs
@@ -7,12 +7,14 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// Implements a CIL instruction handler for <c>ldsfld</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Ldsfld)]
-    public class LdsFldHandler : FallThroughOpCodeHandler
+    public class LdsFldHandler : FieldOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(
+            CilExecutionContext context, 
+            CilInstruction instruction, 
+            IFieldDescriptor field)
         {
-            var field = (IFieldDescriptor) instruction.Operand!;
             var fieldSpan = context.Machine.StaticFields.GetFieldSpan(field);
             context.CurrentFrame.EvaluationStack.Push(fieldSpan, field.Signature!.FieldType);
             return CilDispatchResult.Success();

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdsFldaHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/LdsFldaHandler.cs
@@ -8,12 +8,14 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// Implements a CIL instruction handler for <c>ldsflda</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Ldsflda)]
-    public class LdsFldaHandler : FallThroughOpCodeHandler
+    public class LdsFldaHandler : FieldOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(
+            CilExecutionContext context, 
+            CilInstruction instruction, 
+            IFieldDescriptor field)
         {
-            var field = (IFieldDescriptor) instruction.Operand!;
             var address = context.Machine.ValueFactory.RentNativeInteger(
                 context.Machine.StaticFields.GetFieldAddress(field));
             context.CurrentFrame.EvaluationStack.Push(new StackSlot(address, StackSlotTypeHint.Integer));

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/StFldHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/StFldHandler.cs
@@ -1,6 +1,5 @@
 using AsmResolver.DotNet;
 using AsmResolver.PE.DotNet.Cil;
-using Echo.Memory;
 using Echo.Platforms.AsmResolver.Emulation.Stack;
 
 namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
@@ -9,15 +8,17 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// Implements a CIL instruction handler for <c>stfld</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Stfld)]
-    public class StFldHandler : FallThroughOpCodeHandler
+    public class StFldHandler : FieldOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(
+            CilExecutionContext context, 
+            CilInstruction instruction, 
+            IFieldDescriptor field)
         {
             var stack = context.CurrentFrame.EvaluationStack;
             var factory = context.Machine.ValueFactory;
             
-            var field = (IFieldDescriptor) instruction.Operand!;
             var value = stack.Pop(field.Signature!.FieldType);
             var instance = stack.Pop();
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/StsFldHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/StsFldHandler.cs
@@ -7,12 +7,14 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
     /// Implements a CIL instruction handler for <c>stsfld</c> operations.
     /// </summary>
     [DispatcherTableEntry(CilCode.Stsfld)]
-    public class StsFldHandler : FallThroughOpCodeHandler
+    public class StsFldHandler : FieldOpCodeHandler
     {
         /// <inheritdoc />
-        protected override CilDispatchResult DispatchInternal(CilExecutionContext context, CilInstruction instruction)
+        protected override CilDispatchResult DispatchInternal(
+            CilExecutionContext context, 
+            CilInstruction instruction, 
+            IFieldDescriptor field)
         {
-            var field = (IFieldDescriptor) instruction.Operand!;
             var value = context.CurrentFrame.EvaluationStack.Pop(field.Signature!.FieldType);
             
             try

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/ClrMockMemory.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/ClrMockMemory.cs
@@ -1,3 +1,4 @@
+
 using System;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 
@@ -109,7 +110,7 @@ public sealed class RuntimeTypeManager
             
             // "Call" the constructor.
             initialization.ConstructorCalled = true;
-                
+
             // Actually find the constructor and call it if it is there.
             var cctor = definition.GetStaticConstructor();
             if (cctor is not null)

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using AsmResolver.DotNet;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Runtime;
+
+/// <summary>
+/// Provides a mechanism for initialization and management of types residing in a virtual machine.
+/// </summary>
+public sealed class RuntimeTypeManager
+{
+    private readonly CilVirtualMachine _machine;
+    
+    private readonly ConcurrentDictionary<ITypeDescriptor, TypeInitialization> _initializations 
+        = new(EqualityComparer<ITypeDescriptor>.Default);
+
+    /// <summary>
+    /// Creates a new runtime type manager.
+    /// </summary>
+    /// <param name="machine">The machine the type is made for.</param>
+    public RuntimeTypeManager(CilVirtualMachine machine)
+    {
+        _machine = machine;
+    }
+
+    private TypeInitialization GetInitialization(ITypeDescriptor type)
+    {
+        if (_initializations.TryGetValue(type, out var initialization))
+            return initialization;
+        
+        var newInitialization = new TypeInitialization(type);
+        while (!_initializations.TryGetValue(type, out initialization))
+        {
+            if (_initializations.TryAdd(type, newInitialization))
+            {
+                initialization = newInitialization;
+                break;
+            }
+        }
+
+        return initialization;
+    }
+
+    /// <summary>
+    /// Handles the type initialization on the provided thread.
+    /// </summary>
+    /// <param name="thread">The thread the initialization is to be called on.</param>
+    /// <param name="type">The type to initialize.</param>
+    /// <returns>The initialization result.</returns>
+    public TypeInitializerResult HandleInitialization(CilThread thread, ITypeDescriptor type)
+    {
+        var initialization = GetInitialization(type);
+
+        lock (initialization)
+        {
+            // If we already have an exception cached as a result of a previous type-load failure, rethrow it.
+            if (!initialization.Exception.IsNull)
+                return TypeInitializerResult.Exception(initialization.Exception);
+            
+            // We only need to call the constructor once.
+            if (initialization.ConstructorCalled)
+                return TypeInitializerResult.NoAction();
+
+            // Try resolve the type that is being initialized.
+            var definition = type.Resolve();
+            if (definition is null)
+            {
+                initialization.Exception = _machine.Heap
+                    .AllocateObject(_machine.ValueFactory.TypeInitializationExceptionType, true)
+                    .AsObjectHandle(_machine);
+                    
+                return TypeInitializerResult.Exception(initialization.Exception);
+            }
+
+            // "Call" the constructor.
+            initialization.ConstructorCalled = true;
+                
+            // Actually find the constructor and call it if it is there.
+            var cctor = definition.GetStaticConstructor();
+            if (cctor is not null)
+            {
+                thread.CallStack.Push(cctor);
+                return TypeInitializerResult.Redirected();
+            }
+
+            return TypeInitializerResult.NoAction();
+        }
+    }
+ 
+    private sealed class TypeInitialization
+    {
+        public TypeInitialization(ITypeDescriptor type)
+        {
+            Type = type;
+        }
+
+        public ITypeDescriptor Type { get; }
+        
+        public bool ConstructorCalled { get; set; }
+
+        public ObjectHandle Exception { get; set; }
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
@@ -42,6 +42,33 @@ public sealed class RuntimeTypeManager
     }
 
     /// <summary>
+    /// Registers the event that a type has failed to initialize. 
+    /// </summary>
+    /// <param name="type">The type that failed to initialize.</param>
+    /// <param name="innerException">The exception object that describes the failure.</param>
+    /// <returns>The resulting TypeInitializationException instance.</returns>
+    public ObjectHandle RegisterTypeInitializationException(ITypeDescriptor type, ObjectHandle innerException)
+    {
+        var initialization = GetInitialization(type);
+        if (!initialization.Exception.IsNull)
+            return initialization.Exception;
+
+        lock (initialization)
+        {
+            if (initialization.Exception.IsNull)
+            {
+                initialization.Exception = _machine.Heap
+                    .AllocateObject(_machine.ValueFactory.TypeInitializationExceptionType, true)
+                    .AsObjectHandle(_machine);
+            }
+            
+            // TODO: incorporate `exceptionObject`.
+        }
+
+        return initialization.Exception;
+    }
+    
+    /// <summary>
     /// Handles the type initialization on the provided thread.
     /// </summary>
     /// <param name="thread">The thread the initialization is to be called on.</param>

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using AsmResolver.DotNet;
+using AsmResolver.DotNet.Signatures;
 
 namespace Echo.Platforms.AsmResolver.Emulation.Runtime;
 
@@ -12,7 +13,7 @@ public sealed class RuntimeTypeManager
     private readonly CilVirtualMachine _machine;
     
     private readonly ConcurrentDictionary<ITypeDescriptor, TypeInitialization> _initializations 
-        = new(EqualityComparer<ITypeDescriptor>.Default);
+        = new(SignatureComparer.Default);
 
     /// <summary>
     /// Creates a new runtime type manager.

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/RuntimeTypeManager.cs
@@ -47,7 +47,7 @@ public sealed class RuntimeTypeManager
     /// <param name="type">The type that failed to initialize.</param>
     /// <param name="innerException">The exception object that describes the failure.</param>
     /// <returns>The resulting TypeInitializationException instance.</returns>
-    public ObjectHandle RegisterTypeInitializationException(ITypeDescriptor type, ObjectHandle innerException)
+    public ObjectHandle RegisterInitializationException(ITypeDescriptor type, ObjectHandle innerException)
     {
         var initialization = GetInitialization(type);
         if (!initialization.Exception.IsNull)
@@ -62,7 +62,7 @@ public sealed class RuntimeTypeManager
                     .AsObjectHandle(_machine);
             }
             
-            // TODO: incorporate `exceptionObject`.
+            // TODO: incorporate `innerException`.
         }
 
         return initialization.Exception;

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/StaticFieldStorage.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/StaticFieldStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AsmResolver;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using Echo.Memory;
@@ -51,6 +52,13 @@ namespace Echo.Platforms.AsmResolver.Emulation.Runtime
             {
                 var layout = _valueFactory.GetTypeValueMemoryLayout(field.Signature!.FieldType);
                 address = _heap.Allocate(layout.Size, true);
+
+                if (field.Resolve() is { IsStatic: true, HasFieldRva: true, FieldRva: IReadableSegment data } def)
+                {
+                    field = def;
+                    _heap.GetChunkSpan(address).Write(data.WriteIntoArray());
+                }
+                
                 _fields.Add(field, address);
             }
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/TypeInitializerResult.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Runtime/TypeInitializerResult.cs
@@ -1,0 +1,60 @@
+using Echo.Platforms.AsmResolver.Emulation.Dispatch;
+
+namespace Echo.Platforms.AsmResolver.Emulation.Runtime;
+
+/// <summary>
+/// Describes a result of a type initialization.
+/// </summary>
+public readonly struct TypeInitializerResult
+{
+    private TypeInitializerResult(bool isNoAction, ObjectHandle exceptionObject)
+    {
+        IsNoAction = isNoAction;
+        ExceptionObject = exceptionObject;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the type initialization does not require any further action.
+    /// </summary>
+    public bool IsNoAction { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether control was redirected to the class constructor of a type.
+    /// </summary>
+    public bool IsRedirectedToConstructor => !IsNoAction;
+    
+    /// <summary>
+    /// Gets the exception that was thrown when initialization the type, if any.
+    /// </summary>
+    public ObjectHandle ExceptionObject { get; }
+
+    /// <summary>
+    /// Creates a result that indicates no further action was taken.
+    /// </summary>
+    /// <returns>The result.</returns>
+    public static TypeInitializerResult NoAction() => new(true, default);
+
+    /// <summary>
+    /// Creates a result that indicates control was redirected to a class constructor.
+    /// </summary>
+    /// <returns>The result.</returns>
+    public static TypeInitializerResult Redirected() => new(false, default);
+
+    /// <summary>
+    /// Creates a result that throws a type initialization exception. 
+    /// </summary>
+    /// <param name="exception">The exception that was thrown.</param>
+    /// <returns>The result.</returns>
+    public static TypeInitializerResult Exception(ObjectHandle exception) => new(false, exception);
+
+    /// <summary>
+    /// Transforms the type initialization result into a <see cref="CilDispatchResult"/>.
+    /// </summary>
+    /// <returns>The new dispatcher result.</returns>
+    public CilDispatchResult ToDispatchResult()
+    {
+        if (!ExceptionObject.IsNull)
+            return CilDispatchResult.Exception(ExceptionObject);
+        return CilDispatchResult.Success();
+    }
+}

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ValueFactory.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/ValueFactory.cs
@@ -49,50 +49,62 @@ namespace Echo.Platforms.AsmResolver.Emulation
             DecimalType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "Decimal").Resolve()!;
+                nameof(System),
+                nameof(Decimal)).Resolve()!;
             
             InvalidProgramExceptionType = new TypeReference(
-                    contextModule, 
-                    contextModule.CorLibTypeFactory.CorLibScope, 
-                    "System",
-                    "InvalidProgramException").Resolve()!;
+                contextModule, 
+                contextModule.CorLibTypeFactory.CorLibScope, 
+                nameof(System),
+                nameof(InvalidProgramException)).Resolve()!;
+            
+            TypeInitializationExceptionType = new TypeReference(
+                contextModule, 
+                contextModule.CorLibTypeFactory.CorLibScope, 
+                nameof(System),
+                nameof(TypeInitializationException)).Resolve()!;
             
             NullReferenceExceptionType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "NullReferenceException").Resolve()!;
+                nameof(System),
+                nameof(NullReferenceException)).Resolve()!;
+            
+            InvalidProgramExceptionType = new TypeReference(
+                contextModule, 
+                contextModule.CorLibTypeFactory.CorLibScope, 
+                nameof(System),
+                nameof(InvalidProgramException)).Resolve()!;
             
             IndexOutOfRangeExceptionType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "IndexOutOfRangeException").Resolve()!;
+                nameof(System),
+                nameof(IndexOutOfRangeException)).Resolve()!;
             
             StackOverflowExceptionType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "StackOverflowException").Resolve()!;
+                nameof(System),
+                nameof(StackOverflowException)).Resolve()!;
             
             MissingMethodExceptionType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "MissingMethodException").Resolve()!;
+                nameof(System),
+                nameof(MissingMethodException)).Resolve()!;
             
             InvalidCastExceptionType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "InvalidCastException").Resolve()!;
+                nameof(System),
+                nameof(InvalidCastException)).Resolve()!;
             
             OverflowExceptionType = new TypeReference(
                 contextModule, 
                 contextModule.CorLibTypeFactory.CorLibScope, 
-                "System",
-                "OverflowException").Resolve()!;
+                nameof(System),
+                nameof(OverflowException)).Resolve()!;
         }
 
         /// <summary>
@@ -102,7 +114,7 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             get;
         }
-        
+
         /// <summary>
         /// Gets a value indicating whether the environment is a 32-bit or 64-bit system.
         /// </summary>
@@ -134,11 +146,19 @@ namespace Echo.Platforms.AsmResolver.Emulation
         {
             get;
         }
-        
+
         /// <summary>
         /// Gets a reference to the <see cref="InvalidProgramException"/> type. 
         /// </summary>
         public ITypeDescriptor InvalidProgramExceptionType
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets a reference to the <see cref="TypeInitializationException"/> type. 
+        /// </summary>
+        public TypeDefinition TypeInitializationExceptionType
         {
             get;
         }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CilVirtualMachineTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CilVirtualMachineTest.cs
@@ -589,6 +589,23 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation
         }
 
         [Fact]
+        public void SteppingWithNestedInitializers()
+        {
+            // Look up metadata.
+            var method = _fixture
+                .MockModule.LookupMember<TypeDefinition>(typeof(ClassWithNestedInitializer.Class1).MetadataToken)
+                .Methods.First(m => m.Name == nameof(ClassWithNestedInitializer.Class1.Method));
+
+            // CAll method.
+            _vm.Invoker = DefaultInvokers.StepIn;
+            var result = _mainThread.Call(method, Array.Empty<BitVector>());
+            
+            // Verify.
+            Assert.NotNull(result);
+            Assert.Equal(1337, result.AsSpan().I32);
+        }
+
+        [Fact]
         public void StaticFieldWithInitialValueUpdate()
         {
             var type = _fixture.MockModule.LookupMember<TypeDefinition>(typeof(ClassWithInitializer).MetadataToken);

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CilVirtualMachineTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/CilVirtualMachineTest.cs
@@ -12,6 +12,7 @@ using Echo.Platforms.AsmResolver.Emulation;
 using Echo.Platforms.AsmResolver.Emulation.Invocation;
 using Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch;
 using Echo.Platforms.AsmResolver.Tests.Mock;
+using Mocks;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -587,5 +588,23 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation
             Assert.Equal(expectedException.GetType().FullName, result.ExceptionObject.GetObjectType().FullName);
         }
 
+        [Fact]
+        public void StaticFieldWithInitialValueUpdate()
+        {
+            var type = _fixture.MockModule.LookupMember<TypeDefinition>(typeof(ClassWithInitializer).MetadataToken);
+            var increment = type.Methods.First(m => m.Name == nameof(ClassWithInitializer.IncrementCounter));
+            var counter = type.Fields.First(f => f.Name == nameof(ClassWithInitializer.Counter));
+            
+            // Verify uninitialized value.
+            Assert.Equal(0, _vm.StaticFields.GetFieldSpan(counter).I32);
+            
+            // Call and verify value.
+            _mainThread.Call(increment, Array.Empty<BitVector>());
+            Assert.Equal(1337 + 1, _vm.StaticFields.GetFieldSpan(counter).I32);
+            _mainThread.Call(increment, Array.Empty<BitVector>());
+            Assert.Equal(1337 + 2, _vm.StaticFields.GetFieldSpan(counter).I32);
+            _mainThread.Call(increment, Array.Empty<BitVector>());
+            Assert.Equal(1337 + 3, _vm.StaticFields.GetFieldSpan(counter).I32);
+        }
     }
 }

--- a/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CallHandlerTest.cs
+++ b/test/Platforms/Echo.Platforms.AsmResolver.Tests/Emulation/Dispatch/ObjectModel/CallHandlerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
@@ -5,6 +6,7 @@ using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Cil;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using Echo.Memory;
+using Echo.Platforms.AsmResolver.Emulation;
 using Echo.Platforms.AsmResolver.Emulation.Invocation;
 using Echo.Platforms.AsmResolver.Emulation.Stack;
 using Echo.Platforms.AsmResolver.Tests.Emulation.Invocation;
@@ -255,6 +257,25 @@ namespace Echo.Platforms.AsmResolver.Tests.Emulation.Dispatch.ObjectModel
             // Verify that the .cctor is called.
             Assert.Same(cctor, Context.Thread.CallStack.Peek(0).Method);
             Assert.Same(method, Context.Thread.CallStack.Peek(1).Method);
+        }
+
+        [Fact]
+        public void CallStepInWithThrowingInitializer()
+        {
+            // Look up metadata.
+            var type = ModuleFixture.MockModule.LookupMember<TypeDefinition>(typeof(ClassWithThrowingInitializer).MetadataToken);
+            var cctor = type.GetStaticConstructor();
+            var method = type.Methods.First(m => m.Name == nameof(ClassWithThrowingInitializer.MethodFieldAccess));
+
+            // Step into method.
+            Context.Machine.Invoker = DefaultInvokers.StepIn;
+            Dispatcher.Dispatch(Context, new CilInstruction(CilOpCodes.Call, method));
+
+            Assert.Same(cctor, Context.Thread.CallStack.Peek(0).Method);
+            Assert.Same(method, Context.Thread.CallStack.Peek(1).Method);
+
+            var exception = Assert.Throws<EmulatedException>(() => Context.Thread.StepOut());
+            Assert.Equal(nameof(TypeInitializationException), exception.ExceptionObject.GetObjectType().Name);
         }
     }
 }

--- a/test/Platforms/Mocks/ClassWithInitializer.cs
+++ b/test/Platforms/Mocks/ClassWithInitializer.cs
@@ -3,8 +3,11 @@ namespace Mocks;
 public class ClassWithInitializer
 {
     public static string Field = "Test";
+    public static int Counter = 1337;
     
     public static string MethodNoFieldAccess() => "MethodNoFieldAccess";
 
     public static string MethodFieldAccess() => "MethodFieldAccess: " + Field;
+
+    public static void IncrementCounter() => Counter++;
 }

--- a/test/Platforms/Mocks/ClassWithInitializer.cs
+++ b/test/Platforms/Mocks/ClassWithInitializer.cs
@@ -1,0 +1,10 @@
+namespace Mocks;
+
+public class ClassWithInitializer
+{
+    public static string Field = "Test";
+    
+    public static string MethodNoFieldAccess() => "MethodNoFieldAccess";
+
+    public static string MethodFieldAccess() => "MethodFieldAccess: " + Field;
+}

--- a/test/Platforms/Mocks/ClassWithNestedInitializer.cs
+++ b/test/Platforms/Mocks/ClassWithNestedInitializer.cs
@@ -1,0 +1,16 @@
+namespace Mocks;
+
+    public class ClassWithNestedInitializer
+    {
+        public class Class1
+        {
+            public static int Field = Class2.Field;
+
+            public static int Method() => Field;
+        }
+
+        public class Class2
+        {
+            public static int Field = 1337;
+        }
+    }

--- a/test/Platforms/Mocks/ClassWithThrowingInitializer.cs
+++ b/test/Platforms/Mocks/ClassWithThrowingInitializer.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Mocks;
+
+public class ClassWithThrowingInitializer
+{
+    public static string Field = "Test";
+    
+    static ClassWithThrowingInitializer()
+    {
+        throw new Exception();
+    }
+    
+    public static string MethodNoFieldAccess() => "MethodNoFieldAccess";
+
+    public static string MethodFieldAccess() => "MethodFieldAccess: " + Field;
+}


### PR DESCRIPTION
Includes the following changes:
- Adds `RuntimeTypeManager` which manages type initialization and can redirect control to a static class constructor (.cctor) if it is available.
- Ensures call and field opcodes are first redirected to type initializers when required.
- Ensures static fields are initialized with their initial value stored in `FieldRva`

This does not include special handling of `beforefieldinit` flagged types yet. This will have to be postponed until CIL method body verification is implemented.