### PR TITLE
Support more generics in callvirt handler

### DIFF
--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirtHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirtHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
@@ -20,8 +21,6 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
             CilInstruction instruction, 
             IList<BitVector> arguments)
         {
-            var method = ((IMethodDescriptor) instruction.Operand!).Resolve();
-
             switch (arguments[0].AsSpan())
             {
                 case { IsFullyKnown: false }:
@@ -35,9 +34,10 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                         .AsObjectHandle(context.Machine));
                 
                 case var objectPointer:
+                    var method = (IMethodDescriptor) instruction.Operand!;
                     var objectType = objectPointer.AsObjectHandle(context.Machine).GetObjectType();
-                    var implementation = FindMethodImplementationInType(objectType.Resolve(), method);
-
+                    var implementation = FindMethodImplementationInType(objectType.Resolve(), method.Resolve());
+                    
                     if (implementation is null)
                     {
                         return MethodDevirtualizationResult.Exception(context.Machine
@@ -47,13 +47,19 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
                             .AsObjectHandle(context.Machine));
                     }
                     
-                    return MethodDevirtualizationResult.Success(implementation);
+                    // instantiate generics
+                    var genericContext = GenericContext.FromMethod(method);
+                    if (genericContext.IsEmpty)
+                        return MethodDevirtualizationResult.Success(implementation);
+                    
+                    var methodRef = objectType.ToTypeDefOrRef().CreateMemberReference(implementation.Name!, implementation.Signature!);
+                    return MethodDevirtualizationResult.Success(genericContext.Method != null ? methodRef.MakeGenericInstanceMethod(genericContext.Method.TypeArguments.ToArray()) : methodRef);
             }
         }
 
         private static MethodDefinition? FindMethodImplementationInType(TypeDefinition? type, MethodDefinition? baseMethod)
         {
-            if (type is null || baseMethod is null || !baseMethod.IsVirtual)
+            if (type is null || baseMethod is null)
                 return baseMethod;
 
             var implementation = default(MethodDefinition);
@@ -134,7 +140,15 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
             for (int i = 0; i < type.MethodImplementations.Count; i++)
             {
                 var impl = type.MethodImplementations[i];
-                if (Comparer.Equals(baseMethod, impl.Declaration))
+
+                // Compare underlying TypeDefOrRef and instantiate any generics to ensure correct comparison.
+                if (!Comparer.Equals(impl.Declaration?.DeclaringType?.ToTypeSignature().GetUnderlyingTypeDefOrRef(), baseMethod.DeclaringType))
+                    continue;
+
+                var context = GenericContext.FromMethod(impl.Declaration!);
+                var implMethodSig = impl.Declaration?.Signature?.InstantiateGenericTypes(context); 
+                var baseMethodSig = baseMethod.Signature?.InstantiateGenericTypes(context);
+                if (Comparer.Equals(baseMethodSig, implMethodSig))
                     return impl.Body?.Resolve();
             }
 

--- a/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirtHandler.cs
+++ b/src/Platforms/Echo.Platforms.AsmResolver/Emulation/Dispatch/ObjectModel/CallVirtHandler.cs
@@ -59,7 +59,7 @@ namespace Echo.Platforms.AsmResolver.Emulation.Dispatch.ObjectModel
 
         private static MethodDefinition? FindMethodImplementationInType(TypeDefinition? type, MethodDefinition? baseMethod)
         {
-            if (type is null || baseMethod is null)
+            if (type is null || baseMethod is null || !baseMethod.IsVirtual)
                 return baseMethod;
 
             var implementation = default(MethodDefinition);


### PR DESCRIPTION
Callvirt doesn't support devirtualizing methods with generic parameters, or finding explicit method implementations using generics in.
Thus, this code will error:
```cs
var module = ModuleDefinition.FromModule(typeof(Usage).Module);
var method = module.GetAllTypes().First(x => x.Name == "Usage")?.Methods.First(x => x.Name == "Use");
var vm = new CilVirtualMachine(module, false);
vm.Invoker = DefaultInvokers.StepIn;

var thread = vm.CreateThread();
var ret = thread.Call(method!, Array.Empty<BitVector>());
Console.WriteLine(Usage.Use() == ret!.AsSpan().I32);
vm.DestroyThread(thread);

public interface ITestInterface<T>
{
    public T TestMethod<U>(T i, U u)
    {
        return i;
    }
}

public class TestClass<C> : ITestInterface<int>
{
    int ITestInterface<int>.TestMethod<U>(int i, U u)
    {
        return i;
    }
}

public static class Usage {
    public static int Use()
    {
        var tc = new TestClass<long>();
        var leet2 = ((ITestInterface<int>)tc).TestMethod<short>(1337, 2);
        return leet2;
    }
}
```

This PR fixes it by instantiating generics before comparison, and when returning the devirtualized result.
~~I also removed the `baseMethod.IsVirtual` check as it prevents the code from executing as well.~~
EDIT: Re-added the `baseMethod.IsVirtual` check, I got confused with it earlier :P