### PR TITLE
ci: replace deprecated set-output command

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,8 +19,8 @@ jobs:
         name: Get git branch information
         shell: bash
         run: |
-          echo "##[set-output name=git_branch;]$(echo $GITHUB_REF)"
-          echo "::set-output name=git_hash::$(git rev-parse --short HEAD)"
+          echo "git_branch=$(echo $GITHUB_REF)" >> $GITHUB_OUTPUT
+          echo "git_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - id: set-vars
         uses: actions/github-script@v7


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.